### PR TITLE
Make anonymiser 12x faster

### DIFF
--- a/src/parsers/copy_row.rs
+++ b/src/parsers/copy_row.rs
@@ -34,10 +34,10 @@ fn get_current_table_information(
     unsplit_columns: &str,
     strategies: &Strategies,
 ) -> CurrentTable {
-    let table_name = table.replace("\"", "");
+    let table_name = table.replace('\"', "");
     let column_list: Vec<String> = unsplit_columns
         .split(", ")
-        .map(|s| s.replace("\"", ""))
+        .map(|s| s.replace('\"', ""))
         .collect();
     let transforms = transforms_from_strategy(strategies, &table_name, &column_list);
 

--- a/src/parsers/copy_row.rs
+++ b/src/parsers/copy_row.rs
@@ -37,7 +37,7 @@ fn get_current_table_information(
     let table_name = table.replace("\"", "");
     let column_list: Vec<String> = unsplit_columns
         .split(", ")
-        .map(|s| s.replace("\"", "").to_string())
+        .map(|s| s.replace("\"", ""))
         .collect();
     let transforms = transforms_from_strategy(strategies, &table_name, &column_list);
 

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -64,7 +64,7 @@ fn transform_row<'line, 'state>(
 }
 
 fn split_row<'line>(line: &'line str) -> std::str::Split<&str> {
-    return line.strip_suffix("\n").unwrap_or(line).split("\t");
+    return line.strip_suffix('\n').unwrap_or(line).split("\t");
 }
 
 #[cfg(test)]

--- a/src/parsers/strategy_validator.rs
+++ b/src/parsers/strategy_validator.rs
@@ -56,12 +56,12 @@ pub fn validate(
 
     let in_strategy_file_but_not_db: Vec<_> = columns_from_strategy_file
         .difference(&columns_from_db)
-        .map(|a| a.clone())
+        .cloned()
         .collect();
 
     let in_db_but_not_strategy_file: Vec<_> = columns_from_db
         .difference(&columns_from_strategy_file)
-        .map(|a| a.clone())
+        .cloned()
         .collect();
 
     match (
@@ -86,7 +86,7 @@ pub fn validate(
 
 fn add_if_present(list: Vec<SimpleColumn>) -> Option<Vec<SimpleColumn>> {
     if list.len() > 0 {
-        let mut new_list = list.clone();
+        let mut new_list = list;
         new_list.sort();
         return Some(new_list);
     } else {

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -88,9 +88,7 @@ fn transform_array(value: &str, transformer: &Transformer, table_name: &str) -> 
                 let transformed =
                     transform(&list_item_without_enclosing_quotes, transformer, table_name);
 
-                let quote = String::from("\"");
-
-                return format!("{}{}{}", quote, transformed, quote);
+                format!("\"{}\"", transformed)
             } else {
                 return transform(list_item, transformer, table_name);
             }

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -31,7 +31,7 @@ pub fn transform<'line>(value: &'line str, transformer: &Transformer, table_name
         return value.to_string();
     }
 
-    if value.starts_with("{") && value.ends_with("}") {
+    if value.starts_with('{') && value.ends_with('}') {
         return transform_array(value, transformer, table_name);
     }
 

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -226,33 +226,33 @@ fn obfuscate_day(value: &str, table_name: &str) -> String {
 
 
 fn scramble(original_value: &str) -> String {
-    lazy_static! {
-        static ref NUMBER_MATCH: Regex = Regex::new(r"[0-9]").unwrap();
-    }
-
-    let mut output_string: String = "".to_string();
     let chars = original_value.chars().collect::<Vec<char>>();
+
+    let mut output_buf = Vec::new();
+    output_buf.reserve(chars.len());
+
+    let mut rng = thread_rng();
 
     for i in 0..chars.len() {
         let current_char = chars[i];
         if current_char == '\\' {
             //The string contains a control character like \t \r \n
-            output_string.push(chars[i]);
+            output_buf.push(current_char);
         } else if current_char == ' ' {
-            output_string.push(current_char);
-        } else if NUMBER_MATCH.is_match(&current_char.to_string()) {
-            let new_char = thread_rng().gen_range(b'0'..=b'9') as char;
-            output_string.push(new_char);
+            output_buf.push(current_char);
+        } else if current_char.is_ascii_digit() {
+            let new_char = rng.gen_range(b'0'..=b'9') as char;
+            output_buf.push(new_char);
         } else if i > 0 && chars[i - 1] == '\\' {
             //The second bit of the control character! e.g. the 'n' bit of '\n'
-            output_string.push(current_char);
+            output_buf.push(current_char);
         } else {
-            let new_char = thread_rng().gen_range(b'a'..=b'z') as char;
-            output_string.push(new_char);
+            let new_char = rng.gen_range(b'a'..=b'z') as char;
+            output_buf.push(new_char);
         }
     }
 
-    return output_string;
+    return output_buf.iter().collect();
 }
 
 #[cfg(test)]

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -224,26 +224,24 @@ fn obfuscate_day(value: &str, table_name: &str) -> String {
 
 
 fn scramble(original_value: &str) -> String {
-    let chars = original_value.chars().collect::<Vec<char>>();
-
+    let mut chars = original_value.chars();
     let mut output_buf = Vec::new();
-    output_buf.reserve(chars.len());
+    output_buf.reserve(chars.clone().count());
 
     let mut rng = thread_rng();
 
-    for i in 0..chars.len() {
-        let current_char = chars[i];
+    while let Some(current_char) = chars.next() {
         if current_char == '\\' {
             //The string contains a control character like \t \r \n
             output_buf.push(current_char);
+            if let Some(c) = chars.next() {
+                output_buf.push(c);
+            }
         } else if current_char == ' ' {
             output_buf.push(current_char);
         } else if current_char.is_ascii_digit() {
             let new_char = rng.gen_range(b'0'..=b'9') as char;
             output_buf.push(new_char);
-        } else if i > 0 && chars[i - 1] == '\\' {
-            //The second bit of the control character! e.g. the 'n' bit of '\n'
-            output_buf.push(current_char);
         } else {
             let new_char = rng.gen_range(b'a'..=b'z') as char;
             output_buf.push(new_char);

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -1,14 +1,14 @@
+use crate::parsers::national_insurance_number;
+use crate::parsers::strategy_structs::{Transformer, TransformerType};
 use base16;
 use base32::Alphabet;
 use chrono::{Datelike, NaiveDate};
 use core::ops::Range;
-use crate::parsers::national_insurance_number;
-use crate::parsers::strategy_structs::{Transformer, TransformerType};
-use fake::Fake;
 use fake::faker::address::en::*;
 use fake::faker::company::en::*;
 use fake::faker::internet::en::*;
 use fake::faker::name::en::*;
+use fake::Fake;
 use lazy_static::lazy_static;
 use rand::{thread_rng, Rng};
 use regex::Regex;
@@ -65,7 +65,6 @@ pub fn transform<'line>(value: &'line str, transformer: &Transformer, table_name
         TransformerType::Scramble => scramble(value),
     }
 }
-
 
 fn transform_array(value: &str, transformer: &Transformer, table_name: &str) -> String {
     lazy_static! {
@@ -221,7 +220,6 @@ fn obfuscate_day(value: &str, table_name: &str) -> String {
         }
     }
 }
-
 
 fn scramble(original_value: &str) -> String {
     let mut chars = original_value.chars();

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -220,7 +220,6 @@ fn obfuscate_day(value: &str, table_name: &str) -> String {
                     )
                     .as_ref(),
                 )
-                .to_string();
         }
     }
 }

--- a/test
+++ b/test
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 cargo install cargo2junit
 cargo fmt -- --check
 cargo test -- -Z unstable-options --format json --report-time | cargo2junit > results.xml


### PR DESCRIPTION
Running on my machine with 1.2Gb db dump on my machine goes from 137s to 11s.

Main optimisations:
* Only compile regexes once
* Remove regex from `scramble`
* Optimise `scramble` to minimise memory allocations