### PR TITLE
Some optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,10 @@ dependencies = [
  "base32",
  "chrono",
  "fake",
+ "fnv",
  "itertools",
  "lazy_static",
+ "mimalloc",
  "openssl",
  "postgres",
  "postgres-openssl",
@@ -223,6 +225,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +451,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f64ad83c969af2e732e907564deb0d0ed393cec4af80776f77dd77a1a427698"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "base32",
  "chrono",
  "fake",
- "fnv",
  "itertools",
  "lazy_static",
  "mimalloc",
@@ -223,12 +222,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ lazy_static = "1.4.0"
 openssl = "0.10.41"
 postgres = "0.19.2"
 postgres-openssl = "0.5.0"
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 regex = "1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3"
 uuid = { version = "0.8", features = [ "v4"] }
+fnv = "1"
+mimalloc = "0.1.29"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3"
 uuid = { version = "0.8", features = [ "v4"] }
-fnv = "1"
 mimalloc = "0.1.29"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,11 @@ use parsers::{db_schema, strategy_file};
 use postgres_openssl::MakeTlsConnector;
 use structopt::StructOpt;
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 fn main() -> Result<(), std::io::Error> {
     let opt = Opts::from_args();
 
@@ -28,12 +33,13 @@ fn main() -> Result<(), std::io::Error> {
                 allow_potential_pii,
                 allow_commercially_sensitive,
             };
-            return anonymiser::anonymise(
+
+            anonymiser::anonymise(
                 input_file,
                 output_file,
                 strategy_file,
                 transformer_overrides,
-            );
+            )?
         }
         Anonymiser::ToCsv {
             output_file,

--- a/src/parsers/national_insurance_number.rs
+++ b/src/parsers/national_insurance_number.rs
@@ -1,11 +1,12 @@
 use rand::seq::SliceRandom;
 
 pub fn random() -> String {
-    return NATIONAL_INSURANCE_NUMBERS
+    NATIONAL_INSURANCE_NUMBERS
         .choose(&mut rand::thread_rng())
         .unwrap()
-        .to_string();
+        .to_string()
 }
+
 pub const NATIONAL_INSURANCE_NUMBERS: [&str; 1001] = [
     "MQ938548A",
     "IG994441D",

--- a/src/parsers/state.rs
+++ b/src/parsers/state.rs
@@ -1,20 +1,19 @@
 use crate::parsers::copy_row::CurrentTableTransforms;
 use crate::parsers::types::Column;
 use crate::parsers::types::Type;
-use fnv::FnvHashMap;
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Types {
-    types: FnvHashMap<String, FnvHashMap<String, Type>>,
+    types: HashMap<String, HashMap<String, Type>>,
 }
 
 impl Types {
-    pub fn new(initial: FnvHashMap<String, FnvHashMap<String, Type>>) -> Self {
+    pub fn new(initial: HashMap<String, HashMap<String, Type>>) -> Self {
         Types { types: initial }
     }
 
-    pub fn insert(&mut self, table_name: &str, column_types: FnvHashMap<String, Type>) {
+    pub fn insert(&mut self, table_name: &str, column_types: HashMap<String, Type>) {
         self.types.insert(table_name.to_string(), column_types);
     }
 
@@ -24,7 +23,7 @@ impl Types {
             .and_then(|table| table.get(column_name))
     }
 
-    pub fn for_table(&self, table_name: &str) -> Option<&FnvHashMap<String, Type>> {
+    pub fn for_table(&self, table_name: &str) -> Option<&HashMap<String, Type>> {
         self.types.get(table_name)
     }
 }
@@ -68,7 +67,7 @@ impl State {
                 table_types
                     .iter()
                     .map(|c| (c.name.clone(), c.data_type.clone()))
-                    .collect::<FnvHashMap<String, Type>>(),
+                    .collect::<HashMap<String, Type>>(),
             );
         }
 

--- a/src/parsers/strategy_file.rs
+++ b/src/parsers/strategy_file.rs
@@ -151,9 +151,12 @@ pub fn to_csv(strategy_file: &str, csv_output_file: &str) -> std::io::Result<()>
 
 fn read_file(file_name: &str) -> Result<Vec<StrategyInFile>, std::io::Error> {
     let result = fs::read_to_string(file_name).map(|file_contents| {
-        let p: Vec<StrategyInFile> = serde_json::from_str(&file_contents)
-            .unwrap_or_else(|_| panic!("Invalid json found in strategy file at '{}'", file_name));
-        p
+        serde_json::from_str::<Vec<StrategyInFile>>(&file_contents).unwrap_or_else(|e| {
+            panic!(
+                "Invalid json found in strategy file at '{}': {:#}",
+                file_name, e
+            )
+        })
     });
 
     match result {

--- a/src/test_builders.rs
+++ b/src/test_builders.rs
@@ -6,6 +6,7 @@ pub mod builders {
     use crate::parsers::strategy_structs::Transformer;
     use crate::parsers::strategy_structs::TransformerType;
     use crate::parsers::types::{SubType, Type};
+    use fnv::FnvHashMap;
     use std::collections::HashMap;
 
     impl ColumnInfo {
@@ -63,7 +64,7 @@ pub mod builders {
 
     #[derive(Default)]
     pub struct TypesBuilder {
-        types: HashMap<String, HashMap<String, Type>>,
+        types: FnvHashMap<String, FnvHashMap<String, Type>>,
     }
 
     impl TypesBuilder {
@@ -90,6 +91,7 @@ pub mod builders {
             };
             self.common_add_type(table_name, column_name, column_type)
         }
+
         fn common_add_type(
             mut self,
             table_name: &str,
@@ -101,7 +103,7 @@ pub mod builders {
             } else {
                 self.types.insert(
                     table_name.to_string(),
-                    HashMap::from([(column_name.to_string(), column_type)]),
+                    HashMap::from_iter([(column_name.to_string(), column_type)]),
                 );
             }
 

--- a/src/test_builders.rs
+++ b/src/test_builders.rs
@@ -6,7 +6,6 @@ pub mod builders {
     use crate::parsers::strategy_structs::Transformer;
     use crate::parsers::strategy_structs::TransformerType;
     use crate::parsers::types::{SubType, Type};
-    use fnv::FnvHashMap;
     use std::collections::HashMap;
 
     impl ColumnInfo {
@@ -64,7 +63,7 @@ pub mod builders {
 
     #[derive(Default)]
     pub struct TypesBuilder {
-        types: FnvHashMap<String, FnvHashMap<String, Type>>,
+        types: HashMap<String, HashMap<String, Type>>,
     }
 
     impl TypesBuilder {


### PR DESCRIPTION
This builds off of https://github.com/Multiverse-io/anonymiser/pull/15, so that should go in first to make the changes here more clear:

Changed the default RNG source to SmallRng - a good comparison is here https://rust-random.github.io/book/guide-rngs.html, there may be even faster ones but the key point here is that we don't need a cryptographically secure implementation so its OK to use a higher performance once

Originally I changed some frequently used hashmaps to use Fnv as the hashing algorithm - It doesn't make a huge difference in this case because the benefits are only seen with very small or large keys (see graphs here https://cglab.ca/~abeinges/blah/hash-rs/), but as an example the average table name length (used as a hashmap key) is 28 bytes so not really any benefit of changing it

The biggest performance win was changing the default allocator to https://crates.io/crates/mimalloc 

Before:
```
rohan@Rohans-MacBook-Pro anonymiser % time cargo run --release anonymise
    Finished release [optimized + debuginfo] target(s) in 0.07s
     Running `target/release/anonymiser anonymise`
cargo run --release anonymise  33.45s user 1.62s system 97% cpu 35.921 total
```

After:
```
rohan@Rohans-MacBook-Pro anonymiser % time cargo run --release anonymise
    Finished release [optimized + debuginfo] target(s) in 0.05s
     Running `target/release/anonymiser anonymise`
cargo run --release anonymise  15.03s user 1.39s system 95% cpu 17.145 total
```
35 -> 17 seconds running on an already anonymised copy of the production DB

There might be more to be done in terms of perf but parallelization is probably the next big thing to do, `rayon` could be a good thing to try if we can find some existing iterators to parallelize. 

I've also used the `anyhow` crate before and it makes error handling a lot easier in some cases as well so that might be something else I can look into