### PR TITLE
Performance tweaks

### DIFF
--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -1,3 +1,4 @@
+use crate::parsers::rng;
 use crate::parsers::row_parser;
 use crate::parsers::state::State;
 use crate::parsers::strategies::Strategies;
@@ -22,6 +23,8 @@ pub fn read(
 
     let mut row_parser_state = State::new();
 
+    let mut rng = rng::get();
+
     loop {
         match reader.read_line(&mut line) {
             Ok(bytes_read) => {
@@ -30,7 +33,8 @@ pub fn read(
                 }
 
                 line = line.to_string();
-                let transformed_row = row_parser::parse(&line, &mut row_parser_state, strategies);
+                let transformed_row =
+                    row_parser::parse(&mut rng, &line, &mut row_parser_state, strategies);
                 file_writer.write_all(transformed_row.as_bytes())?;
                 line.clear();
             }

--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -32,7 +32,6 @@ pub fn read(
                     break;
                 }
 
-                line = line.to_string();
                 let transformed_row =
                     row_parser::parse(&mut rng, &line, &mut row_parser_state, strategies);
                 file_writer.write_all(transformed_row.as_bytes())?;

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -2,6 +2,7 @@ pub mod copy_row;
 pub mod create_row;
 pub mod db_schema;
 pub mod national_insurance_number;
+pub mod rng;
 pub mod row_parser;
 pub mod sanitiser;
 pub mod state;

--- a/src/parsers/rng.rs
+++ b/src/parsers/rng.rs
@@ -1,0 +1,6 @@
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+
+pub fn get() -> SmallRng {
+    SmallRng::from_rng(rand::thread_rng()).unwrap_or_else(|_| SmallRng::from_entropy())
+}

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -1,7 +1,6 @@
 use crate::parsers::copy_row;
 use crate::parsers::copy_row::CurrentTableTransforms;
 use crate::parsers::create_row;
-use crate::parsers::rng;
 use crate::parsers::sanitiser;
 use crate::parsers::state::*;
 use crate::parsers::strategies::Strategies;
@@ -162,6 +161,7 @@ fn split_row(line: &str) -> std::str::Split<char> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::rng;
     use crate::parsers::strategy_structs::{ColumnInfo, DataCategory, TransformerType};
     use crate::parsers::types::{SubType, Type};
     use std::collections::HashMap;

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -41,12 +41,12 @@ fn row_type(line: &str, state: &Position) -> RowType {
     }
 }
 
-pub fn parse<'a>(
+pub fn parse<'line>(
     rng: &mut SmallRng,
-    line: &'a str,
+    line: &'line str,
     state: &mut State,
     strategies: &Strategies,
-) -> Cow<'a, str> {
+) -> Cow<'line, str> {
     let sanitised_line = sanitiser::trim(line);
     match (
         row_type(sanitised_line, &state.position),

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -39,11 +39,7 @@ fn row_type(line: &str, state: &Position) -> RowType {
     }
 }
 
-pub fn parse<'a, 'b, 'c>(
-    line: &'a str,
-    state: &'b mut State,
-    strategies: &'c Strategies,
-) -> Cow<'a, str> {
+pub fn parse<'a>(line: &'a str, state: &mut State, strategies: &Strategies) -> Cow<'a, str> {
     let sanitised_line = sanitiser::trim(line);
     match (
         row_type(sanitised_line, &state.position),

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -86,7 +86,7 @@ pub fn parse<'line>(
             let transformed = Cow::from(transform_row(
                 rng,
                 sanitised_line,
-                &current_table,
+                current_table,
                 &state.types,
             ));
             state.update_position(Position::InCopy {

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -1,5 +1,4 @@
 use crate::parsers::national_insurance_number;
-use crate::parsers::rng;
 use crate::parsers::strategy_structs::{Transformer, TransformerType};
 use crate::parsers::types::Type::Array;
 use crate::parsers::types::Type::SingleValue;
@@ -45,13 +44,7 @@ pub fn transform<'line>(
         sub_type: underlying_type,
     } = column_type
     {
-        return Cow::from(transform_array(
-            rng,
-            value,
-            underlying_type,
-            transformer,
-            table_name,
-        ));
+        return transform_array(rng, value, underlying_type, transformer, table_name);
     }
 
     let unique = get_unique();
@@ -107,7 +100,7 @@ fn transform_array<'value>(
                 let list_item_without_enclosing_quotes = &list_item[1..list_item.len() - 1];
                 let transformed = transform(
                     rng,
-                    &list_item_without_enclosing_quotes,
+                    list_item_without_enclosing_quotes,
                     &sub_type,
                     transformer,
                     table_name,
@@ -283,6 +276,7 @@ fn scramble(rng: &mut SmallRng, original_value: &str) -> String {
 mod tests {
     use super::*;
     use crate::parsers::national_insurance_number;
+    use crate::parsers::rng;
     use regex::Regex;
 
     const TABLE_NAME: &str = "gert_lush_table";

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -256,28 +256,27 @@ fn obfuscate_day(value: &str, table_name: &str) -> String {
 }
 
 fn scramble(rng: &mut SmallRng, original_value: &str) -> String {
-    let mut chars = original_value.chars();
-    let mut output_buf = String::with_capacity(original_value.len());
-
-    while let Some(current_char) = chars.next() {
-        if current_char == '\\' {
-            //The string contains a control character like \t \r \n
-            output_buf.push(current_char);
-            if let Some(c) = chars.next() {
-                output_buf.push(c);
+    let mut last_was_backslash = false;
+    original_value
+        .chars()
+        .map(|c| {
+            if last_was_backslash {
+                return c;
             }
-        } else if current_char == ' ' {
-            output_buf.push(current_char);
-        } else if current_char.is_ascii_digit() {
-            let new_char = rng.gen_range(b'0'..=b'9') as char;
-            output_buf.push(new_char);
-        } else {
-            let new_char = rng.gen_range(b'a'..=b'z') as char;
-            output_buf.push(new_char);
-        }
-    }
 
-    output_buf
+            last_was_backslash = false;
+            if c == '\\' {
+                last_was_backslash = true;
+                c
+            } else if c == ' ' {
+                c
+            } else if c.is_ascii_digit() {
+                rng.gen_range(b'0'..=b'9') as char
+            } else {
+                rng.gen_range(b'a'..=b'z') as char
+            }
+        })
+        .collect::<String>()
 }
 
 #[cfg(test)]

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -86,13 +86,13 @@ pub fn transform<'line>(
     }
 }
 
-fn transform_array<'a>(
+fn transform_array<'value>(
     rng: &mut SmallRng,
-    value: &'a str,
+    value: &'value str,
     underlying_type: &SubType,
     transformer: &Transformer,
     table_name: &str,
-) -> Cow<'a, str> {
+) -> Cow<'value, str> {
     let is_string_array = underlying_type == &SubType::Character;
     let unsplit_array = &value[1..value.len() - 1];
 

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -52,36 +52,35 @@ pub fn transform<'line>(
     }
 
     let unique = get_unique();
-    let transformed_string = match transformer.name {
+
+    match transformer.name {
         TransformerType::Error => {
             panic!("Error transform still in place for table: {}", table_name)
         }
-        TransformerType::EmptyJson => "{}".to_string(),
-        TransformerType::FakeBase16String => fake_base16_string(),
-        TransformerType::FakeBase32String => fake_base32_string(),
-        TransformerType::FakeCity => CityName().fake(),
-        TransformerType::FakeCompanyName => fake_company_name(&transformer.args, unique),
-        TransformerType::FakeEmail => fake_email(&transformer.args, unique),
-        TransformerType::FakeFirstName => FirstName().fake(),
-        TransformerType::FakeFullAddress => fake_full_address(),
-        TransformerType::FakeFullName => fake_full_name(),
-        TransformerType::FakeIPv4 => IPv4().fake(),
-        TransformerType::FakeLastName => LastName().fake(),
-        TransformerType::FakeNationalIdentityNumber => fake_national_identity_number(),
-        TransformerType::FakePostCode => fake_postcode(value),
-        TransformerType::FakePhoneNumber => fake_phone_number(value),
-        TransformerType::FakeStreetAddress => fake_street_address(),
-        TransformerType::FakeState => StateName().fake(),
-        TransformerType::FakeUsername => fake_username(&transformer.args, unique),
+        TransformerType::EmptyJson => Cow::from("{}"),
+        TransformerType::FakeBase16String => Cow::from(fake_base16_string()),
+        TransformerType::FakeBase32String => Cow::from(fake_base32_string()),
+        TransformerType::FakeCity => Cow::from(CityName().fake::<String>()),
+        TransformerType::FakeCompanyName => Cow::from(fake_company_name(&transformer.args, unique)),
+        TransformerType::FakeEmail => Cow::from(fake_email(&transformer.args, unique)),
+        TransformerType::FakeFirstName => Cow::from(FirstName().fake::<String>()),
+        TransformerType::FakeFullAddress => Cow::from(fake_full_address()),
+        TransformerType::FakeFullName => Cow::from(fake_full_name()),
+        TransformerType::FakeIPv4 => Cow::from(IPv4().fake::<String>()),
+        TransformerType::FakeLastName => Cow::from(LastName().fake::<String>()),
+        TransformerType::FakeNationalIdentityNumber => Cow::from(fake_national_identity_number()),
+        TransformerType::FakePostCode => Cow::from(fake_postcode(value)),
+        TransformerType::FakePhoneNumber => Cow::from(fake_phone_number(value)),
+        TransformerType::FakeStreetAddress => Cow::from(fake_street_address()),
+        TransformerType::FakeState => Cow::from(StateName().fake::<String>()),
+        TransformerType::FakeUsername => Cow::from(fake_username(&transformer.args, unique)),
         //TODO not tested VV
-        TransformerType::FakeUUID => Uuid::new_v4().to_string(),
-        TransformerType::Fixed => fixed(&transformer.args, table_name),
-        TransformerType::Identity => value.to_string(),
-        TransformerType::ObfuscateDay => obfuscate_day(value, table_name),
-        TransformerType::Scramble => scramble(value),
-    };
-
-    Cow::from(transformed_string)
+        TransformerType::FakeUUID => Cow::from(Uuid::new_v4().to_string()),
+        TransformerType::Fixed => Cow::from(fixed(&transformer.args, table_name)),
+        TransformerType::Identity => Cow::from(value),
+        TransformerType::ObfuscateDay => Cow::from(obfuscate_day(value, table_name)),
+        TransformerType::Scramble => Cow::from(scramble(value)),
+    }
 }
 
 fn transform_array<'a>(
@@ -101,9 +100,7 @@ fn transform_array<'a>(
         .split(", ")
         .map(|list_item| {
             if is_string_array {
-                let mut list_item_without_enclosing_quotes = list_item.to_string();
-                list_item_without_enclosing_quotes.remove(0);
-                list_item_without_enclosing_quotes.pop();
+                let list_item_without_enclosing_quotes = &list_item[1..list_item.len() - 1];
                 let transformed = transform(
                     &list_item_without_enclosing_quotes,
                     &sub_type,


### PR DESCRIPTION
## Description

This PR contains various performance tweaks that yield a cumulative improvement of ~4 seconds on my dev machine. It also reduces memory usage by about 30%.

Changes:

* Replace `String` with `Cow<str>` in a number of places. This makes it possible to reuse the same allocation in cases where a column's value is unchanged.
* Slightly faster implementation of `scramble`. (This is called much more frequently than the other transformation functions, so speeding it up has a small but detectable impact on performance.)
* Avoid the (admittedly small!) cost of repeatedly initializing `SmallRng` by passing through a mutable reference to an instance of it.
* Avoid cloning `state.position` every time `row_parser::parse(...)` is called. This has quite a significant effect, as the `position` field contains `types: HashMap` – which was therefore getting cloned for every row.

## Performance data

### Time

Average of 20 runs of `/usr/bin/time ./target/release/anonymiser anonymise -i ./foo.sql -s ./strategy.json -o out.sql`:

| This branch   | Main |
| ------------- | ----- |
| 13.0s              | 17.2s  |

### Space

Peak memory footprint (from a single hot run using `/usr/bin/time -l`):

| This branch   | Main |
| ------------- | ----- |
| 9.5GB             | 14.2GB  |


## Parallelism?

I looked into parallelizing the code but it's not trivial. As currently written, processing of each row in the input file depends on the previous rows. Individual rows do not involve enough computation for row-level parallelism to be worth the additional overhead of spawning threads (or passing messages to a thread pool).