### PR TITLE
Remove some unused state updates, adding a todo 

### DIFF
--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -82,15 +82,9 @@ pub fn parse<'line>(
             state.update_position(Position::Normal);
             Cow::from(line)
         }
-        (RowType::CopyBlockRow, Position::InCopy { ref current_table }) => {
-            let transformed = Cow::from(transform_row(
-                rng,
-                sanitised_line,
-                current_table,
-                &state.types,
-            ));
-            transformed
-        }
+        (RowType::CopyBlockRow, Position::InCopy { ref current_table }) => Cow::from(
+            transform_row(rng, sanitised_line, current_table, &state.types),
+        ),
 
         (RowType::Normal, Position::Normal) => Cow::from(line),
         (row_type, position) => {

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -89,16 +89,10 @@ pub fn parse<'line>(
                 current_table,
                 &state.types,
             ));
-            state.update_position(Position::InCopy {
-                current_table: current_table.clone(),
-            });
             transformed
         }
 
-        (RowType::Normal, Position::Normal) => {
-            state.update_position(Position::Normal);
-            Cow::from(line)
-        }
+        (RowType::Normal, Position::Normal) => Cow::from(line),
         (row_type, position) => {
             panic!(
                 "omg! invalid combo of rowtype: {:?} and position: {:?}",

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -119,6 +119,9 @@ fn transform_row(
     let mut transformed = column_values.enumerate().map(|(i, value)| {
         let current_column = &current_table.columns[i];
         let column_type = types
+            //TODO this lookup, we do a double hashmap lookup for every column... already know the
+            //table, so we shouldnt need to do both... can we cache the current tables columns
+            //hashmap?
             .lookup(&current_table.table_name, &current_column.name)
             .unwrap_or_else(|| {
                 panic!(


### PR DESCRIPTION
i ran a flamegraph and one of the larger blocks is the types lookup in the row_parser..
we actually do a double hashmap lookup where we dont need to so i added a todo as a small piece if someone fancies refactoring 

![pretty](https://user-images.githubusercontent.com/7792186/188486629-1845429f-3cee-4bad-914f-c1339d6774b2.svg)

zoom of the lookup bit (19% of total time)
![Untitled](https://user-images.githubusercontent.com/7792186/188602527-5189a046-a9eb-4295-b03e-2dc4e8c7f259.png)
