### PR TITLE
Add --scramble-blank option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,12 @@ fn main() -> Result<(), std::io::Error> {
             compress_output,
             allow_potential_pii,
             allow_commercially_sensitive,
+            scramble_blank,
         } => {
             let transformer_overrides = TransformerOverrides {
                 allow_potential_pii,
                 allow_commercially_sensitive,
+                scramble_blank,
             };
 
             anonymiser::anonymise(

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -28,6 +28,9 @@ pub enum Anonymiser {
         /// Does not transform Commercially sensitive data types
         #[structopt(long)]
         allow_commercially_sensitive: bool,
+        /// Modifies the "Scramble" transformer to use an underscore for all replaced non-whitespace characters
+        #[structopt(long)]
+        scramble_blank: bool,
     },
 
     /// Creates a CSV file of PII or PotentialPII fields

--- a/src/parsers/strategies.rs
+++ b/src/parsers/strategies.rs
@@ -544,7 +544,6 @@ mod tests {
                 allow_potential_pii: true,
                 allow_commercially_sensitive: true,
                 scramble_blank: true,
-                ..Default::default()
             },
         )
         .expect("we shouldnt have duplicate columns!");

--- a/src/parsers/strategy_structs.rs
+++ b/src/parsers/strategy_structs.rs
@@ -127,6 +127,7 @@ pub enum TransformerType {
     Identity,
     ObfuscateDay,
     Scramble,
+    ScrambleBlank,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -140,6 +141,7 @@ pub struct Transformer {
 pub struct TransformerOverrides {
     pub allow_potential_pii: bool,
     pub allow_commercially_sensitive: bool,
+    pub scramble_blank: bool,
 }
 
 impl TransformerOverrides {
@@ -147,6 +149,13 @@ impl TransformerOverrides {
         Self {
             allow_potential_pii: false,
             allow_commercially_sensitive: false,
+            scramble_blank: false,
         }
+    }
+}
+
+impl Default for TransformerOverrides {
+    fn default() -> Self {
+        Self::none()
     }
 }


### PR DESCRIPTION
At the moment, a compressed download of a DB we use this on is around ~1.3GB, which can take a while to download on slower connections

Part of the reason for this is the scramble transformer, which takes text like "Sample Text 123" and converts it to "kldrxv ltca 950" which is nice but also not very useful, and completely random which makes it hard to compress efficiently

By passing the flag implemented in this PR we replace it with just underscores, still retaining any whitespace, which compresses more efficiently.

Theoretically we could also remove the content completely, but we might run into issues with things like minimum lengths, or being unsure if content was actually present there.

This reduces the size quite significantly down to ~350MB, making the download faster