### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ anonymiser-aarch64-apple-darwin
 anonymiser-x86_64-apple-darwin
 anonymiser-x86_64-unknown-linux-gnu
 anonymiser-x86_64-unknown-linux-musl
+
+.direnv

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /target
+/result
 results.xml
 *.sql
 *.csv

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 A command line tool to read a sql backup (created with pg_dump) and anonymise it based on a strategy file
 
 ## Installing
-Can be downloded from [here](https://github.com/Multiverse-io/anonymiser/releases) or installed using asdf using [this](https://github.com/Multiverse-io/asdf-anonymiser)
+There are a few options:
+
+1. The binary can be downloded from [the releases page](https://github.com/Multiverse-io/anonymiser/releases).
+2. An [asdf](https://github.com/asdf-vm/asdf) plugin is available at [Multiverse-io/asdf-anonymiser](https://github.com/Multiverse-io/asdf-anonymiser).
+3. This repository is a [Nix flake](https://nix.dev/concepts/flakes) and can be used as input to your own flakes.
 
 ## Running
 1. Ensure you have a strategy.json file (you can generate a blank one using `anonymiser generate-strategies --db-url postgres://postgres:postgres@localhost/DB_NAME`
@@ -12,6 +16,13 @@ Can be downloded from [here](https://github.com/Multiverse-io/anonymiser/release
 4. Run the anonymiser with `anonymiser anonymise -i clear_text_dump.sql -o anonymised.sql -s strategy.json`
 
 For further command line options you can use `--help`
+
+## Development
+
+If you have Nix installed you can run `nix develop` inside the repository to open a subshell with the requisite development tools made available to you.
+If you also have direnv installed you can run `direnv allow` to automatically open the subshell upon entering the repository directory.
+
+Otherwise you just need to ensure a Rust toolchain is available, as provided by [rustup](https://www.rust-lang.org/tools/install) for example.
 
 ## Creating releases
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Anonymiser [![CircleCI](https://circleci.com/gh/Multiverse-io/anonymiser/tree/main.svg?style=svg&circle-token=f96c8ae882765c9cb2219d4539a5bed696451202)](https://circleci.com/gh/Multiverse-io/anonymiser/tree/main)
+# Anonymiser [![CircleCI](https://dl.circleci.com/status-badge/img/gh/Multiverse-io/anonymiser/tree/main.svg?style=svg)](https://circleci.com/gh/Multiverse-io/anonymiser/tree/main)
 
 A command line tool to read a sql backup (created with pg_dump) and anonymise it based on a strategy file
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697009197,
-        "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
+        "lastModified": 1705635624,
+        "narHash": "sha256-DU0schxQOtBNO1c9hUsgYl+QMOXQMfRT7Qw/mg+ayno=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01441e14af5e29c9d27ace398e6dd0b293e25a54",
+        "rev": "4471857c0a4a8a0ffc7bdbeaf1b998746ce12a82",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697076655,
-        "narHash": "sha256-NcCtVUOd0X81srZkrdP8qoA1BMsPdO2tGtlZpsGijeU=",
+        "lastModified": 1705630663,
+        "narHash": "sha256-f+kcR17ZtwMyCEtNAfpD0Mv6qObNKoJ41l+6deoaXi8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aa7584f5bbf5947716ad8ec14eccc0334f0d28f0",
+        "rev": "47cac072a313d9cce884b9ea418d2bf712fa23dd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697009197,
+        "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "01441e14af5e29c9d27ace398e6dd0b293e25a54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1697076655,
+        "narHash": "sha256-NcCtVUOd0X81srZkrdP8qoA1BMsPdO2tGtlZpsGijeU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "aa7584f5bbf5947716ad8ec14eccc0334f0d28f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,7 @@
             [
               openssl
             ]
-            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-            (with pkgs; [darwin.apple_sdk.frameworks.Security]);
+            ++ pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
 
           checkFlags = [
             # Skip tests which require acces to a PostgreSQL server.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "A PostgreSQL anonymisation CLI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      overlays = [rust-overlay.overlays.default];
+      pkgs = import nixpkgs {inherit overlays system;};
+
+      rust = pkgs.rust-bin.stable.latest.default.override {extensions = ["rust-src"];};
+      rustPlatform = pkgs.makeRustPlatform {
+        cargo = rust;
+        rustc = rust;
+      };
+
+      manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+    in {
+      # `nix develop`.
+      devShells = {
+        default = pkgs.mkShell {
+          inputsFrom = [self.packages.${system}.anonymiser];
+          buildInputs = with pkgs; [rust-analyzer];
+        };
+      };
+
+      # `nix fmt`.
+      formatter = pkgs.alejandra;
+
+      # `nix build`.
+      packages = {
+        anonymiser = rustPlatform.buildRustPackage {
+          pname = manifest.name;
+          version = manifest.version;
+          src = pkgs.nix-gitignore.gitignoreSource [] ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          # Compile-time dependencies.
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          # Run-time dependencies.
+          buildInputs = with pkgs;
+            [
+              openssl
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
+            (with pkgs; [darwin.apple_sdk.frameworks.Security]);
+
+          checkFlags = [
+            # Skip tests which require acces to a PostgreSQL server.
+            "--skip=anonymiser::tests::successfully_transforms"
+            "--skip=parsers::db_schema::tests::can_read_db_columns"
+          ];
+        };
+        default = self.packages.${system}.anonymiser;
+      };
+    });
+}


### PR DESCRIPTION
This addresses [sc-34401](https://app.shortcut.com/multiverse/story/34401/add-nix-flake-to-anonymiser). That ticket is part of an effort to provide a Nix flake for [Multiverse-io/platform](https://github.com/Multiverse-io/platform), which depends on anonymiser.

## Pros

We could [bundle a Nix package definition into the platform source](https://github.com/Multiverse-io/platform/blob/a59bdf6d771af0c5181dc44d928c681de1c321cc/nix/anonymiser.nix), but it's more useful to include it in anonymiser directly as its developers can benefit from Nix-based dependency management.

Once Nix and direnv are installed, the main benefit of having a flake is that entering the repository directory automatically starts a subshell containing the full development dependencies (cargo, openssl, rust-analyzer, rust-clippy, …). One can then use the usual Rust development flow (`cargo build`, `cargo test`, …) or build and run the package with Nix (`nix build`, `nix run . -- --version`, …).

The secondary benefit is that other flakes can easily consume this project for their own needs. For example:

```nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
  # One could choose to follow a tag explicitly here, or just put the latest in the lockfile.
  inputs.anonymiser.url = "github:Multiverse-io/anonymiser";
  inputs.anonymiser.inputs.nixpkgs.follows = "nixpkgs";

  outputs = {self, nixpkgs, anonymiser}: let
    system = "aarch64-darwin";
    pkgs = import nixpkgs { inherit system; };
  in {
    devShells.${system}.default = pkgs.mkShell {
      buildInputs = [anonymiser.packages.${system}.anonymiser];
    };
  };
}
```

## Cons

IMO the strongest argument _against_ include a flake is that Multiverse doesn't have any Nix buy-in today. Supporting any new tooling should come with the usual discussions of benefit vs. cost, which we haven't really had explicitly so far.

A weak argument against that is that we could merge this Nix stuff for now and see where it goes. ("Weak" because once something's merged it's easy for it to rot if not explicitly supported.)

## To do

If we like the approach, it would be good to run something like `nix build` in the CI. This will ensure the flake builds the package successfully, including a pass of the test suite.