### PR TITLE
add an email or phone transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ The following data categories are supported
 - FakeCompanyName * - Random Company Name from [faker](https://github.com/cksac/fake-rs)
 - FakeEmail * - Random email address from [faker](https://github.com/cksac/fake-rs)
 - FakeEmailOrPhone * - Either a random phone number OR a random email depending on whether the existing data starts with a `+` and doesn't contain an `@` symbol or not!
-- Random email address from [faker](https://github.com/cksac/fake-rs)
 - FakeFirstName - Random first name from [faker](https://github.com/cksac/fake-rs)
 - FakeFullAddress - Random address made up of segments from [faker](https://github.com/cksac/fake-rs)
 - FakeFullName - Random first plus last name from [faker](https://github.com/cksac/fake-rs)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The following data categories are supported
 - FakeCity - Random city from [faker](https://github.com/cksac/fake-rs)
 - FakeCompanyName * - Random Company Name from [faker](https://github.com/cksac/fake-rs)
 - FakeEmail * - Random email address from [faker](https://github.com/cksac/fake-rs)
+- FakeEmailOrPhone * - Either a random phone number OR a random email depending on whether the existing data starts with a `+` and doesn't contain an `@` symbol or not!
+- Random email address from [faker](https://github.com/cksac/fake-rs)
 - FakeFirstName - Random first name from [faker](https://github.com/cksac/fake-rs)
 - FakeFullAddress - Random address made up of segments from [faker](https://github.com/cksac/fake-rs)
 - FakeFullName - Random first plus last name from [faker](https://github.com/cksac/fake-rs)

--- a/src/parsers/strategy_file.rs
+++ b/src/parsers/strategy_file.rs
@@ -49,12 +49,10 @@ pub fn to_csv(strategy_file: &str, csv_output_file: &str) -> std::io::Result<()>
         .iter()
         .flat_map(|strategy| {
             strategy.columns.iter().filter_map(|column| {
-                if column.data_category == DataCategory::Pii
-                    || column.data_category == DataCategory::PotentialPii
-                {
+                if column.data_category != DataCategory::General {
                     Some(format!(
-                        "{}, {}, {}",
-                        strategy.table_name, column.name, column.description
+                        "{}, {}, {:?}, {}",
+                        strategy.table_name, column.name, column.data_category, column.description
                     ))
                 } else {
                     None

--- a/src/parsers/strategy_structs.rs
+++ b/src/parsers/strategy_structs.rs
@@ -111,6 +111,7 @@ pub enum TransformerType {
     FakeCity,
     FakeCompanyName,
     FakeEmail,
+    FakeEmailOrPhone,
     FakeFirstName,
     FakeFullAddress,
     FakeFullName,

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -217,7 +217,7 @@ fn fake_email_or_phone(
     optional_args: &Option<HashMap<String, String>>,
     unique: usize,
 ) -> String {
-    if current_value.starts_with("+") && !current_value.contains("@") {
+    if current_value.starts_with('+') && !current_value.contains('@') {
         fake_phone_number(current_value)
     } else {
         fake_email(optional_args, unique)
@@ -685,7 +685,7 @@ mod tests {
             TABLE_NAME,
         );
         assert!(new_email != email);
-        assert!(new_email.contains("@"));
+        assert!(new_email.contains('@'));
     }
 
     #[test]


### PR DESCRIPTION
Heya y'all!

hope you're well, 

i had the need to be able to anonymise a field that was either a phone number OR an email (depending on a `type` variable in another column... i don't think we can couple one column to another so thought this was a better approach... 

wdyt? its pretty simple?

i also added all non General data types to the csv output as i think it makes more sense? you can always filter out the ones you dont need in the csv right?

lmk if this seems sensible!

Dan