### PR TITLE
allow gzip compression option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,12 +124,14 @@ jobs:
     macos:
       xcode: 13.4.1
     environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - checkout
       - restore_cache:
           keys:
             - << pipeline.parameters.cache-key >>-cargo-mac-release-cache-{{ checksum "Cargo.lock" }}
+      - run: brew install cmake
       - run: TAG="${CIRCLE_TAG:-v0.0.0}"; ./update_version $TAG
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: rustup install 1.67

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,7 @@ dependencies = [
  "base32",
  "chrono",
  "fake",
+ "flate2",
  "itertools",
  "lazy_static",
  "log",
@@ -189,6 +196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +227,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -287,6 +312,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "libz-ng-sys",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -525,6 +561,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +611,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
 dependencies = [
  "libmimalloc-sys",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ base32 = "0.4.0"
 chrono = "0.4"
 itertools = "0.10.5"
 fake = "2.4"
+flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }
 lazy_static = "1.4.0"
 native-tls = "0.2.11"
 postgres = "0.19.4"

--- a/src/anonymiser.rs
+++ b/src/anonymiser.rs
@@ -49,7 +49,7 @@ mod tests {
             "test_files/dump_file.sql".to_string(),
             "test_files/results.sql".to_string(),
             "non_existing_strategy_file.json".to_string(),
-            false,
+            None,
             TransformerOverrides::none(),
         )
         .is_ok());
@@ -62,7 +62,7 @@ mod tests {
             "non_existing_input_file.sql".to_string(),
             "test_files/results.sql".to_string(),
             "test_files/strategy.json".to_string(),
-            false,
+            None,
             TransformerOverrides::none(),
         )
         .is_ok());
@@ -74,7 +74,7 @@ mod tests {
             "test_files/dump_file.sql".to_string(),
             "test_files/results.sql".to_string(),
             "test_files/strategy.json".to_string(),
-            false,
+            None,
             TransformerOverrides::none(),
         )
         .is_ok());

--- a/src/anonymiser.rs
+++ b/src/anonymiser.rs
@@ -1,3 +1,4 @@
+use crate::compression_type::CompressionType;
 use crate::file_reader;
 use crate::parsers::strategies::Strategies;
 use crate::parsers::strategy_file;
@@ -7,7 +8,7 @@ pub fn anonymise(
     input_file: String,
     output_file: String,
     strategy_file: String,
-    compress_output: bool,
+    compress_output: Option<Option<CompressionType>>,
     transformer_overrides: TransformerOverrides,
 ) -> Result<(), std::io::Error> {
     match strategy_file::read(&strategy_file) {

--- a/src/compression_type.rs
+++ b/src/compression_type.rs
@@ -1,0 +1,20 @@
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub enum CompressionType {
+    Zstd,
+    Gzip,
+}
+type ParseError = &'static str;
+
+impl FromStr for CompressionType {
+    type Err = ParseError;
+    fn from_str(compression_type: &str) -> Result<Self, Self::Err> {
+        match compression_type {
+            "true" => Ok(CompressionType::Zstd),
+            "zstd" => Ok(CompressionType::Zstd),
+            "gzip" => Ok(CompressionType::Gzip),
+            _ => Err("Could not parse compression type"),
+        }
+    }
+}

--- a/src/compression_type.rs
+++ b/src/compression_type.rs
@@ -11,7 +11,6 @@ impl FromStr for CompressionType {
     type Err = ParseError;
     fn from_str(compression_type: &str) -> Result<Self, Self::Err> {
         match compression_type {
-            "true" => Ok(CompressionType::Zstd),
             "zstd" => Ok(CompressionType::Zstd),
             "gzip" => Ok(CompressionType::Gzip),
             _ => Err("Could not parse compression type"),

--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -108,7 +108,7 @@ mod tests {
         let _ = fs::remove_file(&output_file).ok();
         let strategies = default_strategies();
 
-        assert!(read(input_file.clone(), output_file.clone(), &strategies, false).is_ok());
+        assert!(read(input_file.clone(), output_file.clone(), &strategies, None).is_ok());
 
         let original =
             fs::read_to_string(&input_file).expect("Something went wrong reading the file");
@@ -120,7 +120,7 @@ mod tests {
     }
 
     #[test]
-    fn can_read_and_output_compressed() {
+    fn can_read_and_output_compressed_with_default() {
         let input_file = "test_files/dump_file.sql".to_string();
         let compressed_file = "test_files/compressed_file_reader_test_results.sql".to_string();
         let uncompressed_file_name = "test_files/uncompressed_file_reader_test_results.sql";
@@ -134,7 +134,40 @@ mod tests {
             input_file.clone(),
             compressed_file.clone(),
             &strategies,
-            true
+            Some(None)
+        )
+        .is_ok());
+
+        uncompress(
+            PathBuf::from(&compressed_file),
+            Some(PathBuf::from(uncompressed_file_name)),
+        )
+        .expect("Should not fail to uncompress!");
+
+        let original =
+            fs::read_to_string(&input_file).expect("Something went wrong reading the file");
+
+        let processed = fs::read_to_string(uncompressed_file_name)
+            .expect("Something went wrong reading the file");
+
+        assert_eq!(original, processed);
+    }
+    #[test]
+    fn can_read_and_output_compressed_with_specific_compression_type() {
+        let input_file = "test_files/dump_file.sql".to_string();
+        let compressed_file = "test_files/compressed_file_reader_test_results.sql".to_string();
+        let uncompressed_file_name = "test_files/uncompressed_file_reader_test_results.sql";
+
+        let _ = fs::remove_file(&compressed_file);
+        let _ = fs::remove_file(uncompressed_file_name);
+
+        let strategies = default_strategies();
+
+        assert!(read(
+            input_file.clone(),
+            compressed_file.clone(),
+            &strategies,
+            Some(Some(CompressionType::Zstd))
         )
         .is_ok());
 

--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -16,7 +16,6 @@ pub fn read(
     strategies: &Strategies,
     compress_output: Option<Option<CompressionType>>,
 ) -> Result<(), std::io::Error> {
-    println!("moo {:?} arguments", compress_output);
     let output_file = File::create(output_file_path)?;
     let mut file_writer: Box<dyn Write> = match compress_output {
         Some(Some(CompressionType::Zstd)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod anonymiser;
+mod compression_type;
 mod file_reader;
 mod fixers;
 mod opts;
@@ -25,6 +26,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 fn main() -> Result<(), std::io::Error> {
     let opt = Opts::from_args();
 
+    println!("{:?}", opt);
     match opt.commands {
         Anonymiser::Anonymise {
             input_file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ static GLOBAL: MiMalloc = MiMalloc;
 fn main() -> Result<(), std::io::Error> {
     let opt = Opts::from_args();
 
-    println!("{:?}", opt);
     match opt.commands {
         Anonymiser::Anonymise {
             input_file,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -21,8 +21,8 @@ pub enum Anonymiser {
         strategy_file: String,
         /// Either just a flag
         /// e.g. '--compress-output' in which case it defaults to zstd
-        /// or with a compression type
-        /// e.g. '--compress-output zstd' or '--compress-output gzip'
+        /// or with a        /// compression type e.g. '--compress-output zstd' or '--compress-output gzip'
+        /// compr
         #[structopt(short, long)]
         compress_output: Option<Option<CompressionType>>,
         /// Does not transform PotentiallPii data types
@@ -75,6 +75,8 @@ pub enum Anonymiser {
     },
 
     /// Uncompress a zstd sql dump to a file, or stdout if no file specified
+    /// Does not currently work for gzip as tools to decompress that are more
+    /// readily available
     Uncompress {
         /// Input file (*.sql.zst)
         #[structopt(short, long)]

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,5 +1,5 @@
+use crate::compression_type::CompressionType;
 use std::path::PathBuf;
-
 use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "Anonymiser", about = "Anonymise your database backups!")]
@@ -19,9 +19,12 @@ pub enum Anonymiser {
         /// Path to the strategy.json file
         #[structopt(short, long, default_value = "./strategy.json")]
         strategy_file: String,
-        /// Compress output using zstd
+        /// Either just a flag
+        /// e.g. '--compress-output' in which case it defaults to zstd
+        /// or with a compression type
+        /// e.g. '--compress-output zstd' or '--compress-output gzip'
         #[structopt(short, long)]
-        compress_output: bool,
+        compress_output: Option<Option<CompressionType>>,
         /// Does not transform PotentiallPii data types
         #[structopt(long)]
         allow_potential_pii: bool,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -21,8 +21,7 @@ pub enum Anonymiser {
         strategy_file: String,
         /// Either just a flag
         /// e.g. '--compress-output' in which case it defaults to zstd
-        /// or with a        /// compression type e.g. '--compress-output zstd' or '--compress-output gzip'
-        /// compr
+        /// or with a compression type e.g. '--compress-output zstd' or '--compress-output gzip'
         #[structopt(short, long)]
         compress_output: Option<Option<CompressionType>>,
         /// Does not transform PotentiallPii data types

--- a/src/uncompress.rs
+++ b/src/uncompress.rs
@@ -26,7 +26,7 @@ mod tests {
             "test_files/dump_file.sql".to_string(),
             "test_files/compress/results.sql".to_string(),
             "test_files/strategy.json".to_string(),
-            false,
+            None,
             TransformerOverrides::none(),
         )
         .unwrap();
@@ -35,7 +35,7 @@ mod tests {
             "test_files/dump_file.sql".to_string(),
             "test_files/compress/results.sql.zst".to_string(),
             "test_files/strategy.json".to_string(),
-            true,
+            Some(None),
             TransformerOverrides::none(),
         )
         .unwrap();


### PR DESCRIPTION
add an option to use gzip compression via the command line..

this uses the higher performance c++ library

i've maintained the existing behaviour so that

`--compress-output` uses zstd
but you can now specify `--compress-output zstd` or `--compress-output gzip`
