### PR TITLE
Whitespace bug

### DIFF
--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -82,9 +82,9 @@ pub fn parse<'line>(
             state.update_position(Position::Normal);
             Cow::from(line)
         }
-        (RowType::CopyBlockRow, Position::InCopy { ref current_table }) => Cow::from(
-            transform_row(rng, sanitised_line, current_table, &state.types),
-        ),
+        (RowType::CopyBlockRow, Position::InCopy { ref current_table }) => {
+            Cow::from(transform_row(rng, line, current_table, &state.types))
+        }
 
         (RowType::Normal, Position::Normal) => Cow::from(line),
         (row_type, position) => {
@@ -436,6 +436,41 @@ mod tests {
         let mut rng = rng::get();
         let transformed_row = parse(&mut rng, table_data_row, &mut state, &strategies);
         assert_eq!("first\tsecond\tthird\n", transformed_row);
+    }
+    #[test]
+    fn whitespace_is_not_removed() {
+        let table_data_row = "   123\t  Peter   \t  Puckleberry   \n";
+        let strategies = Strategies::new_from("public.users".to_string(), HashMap::new());
+
+        let mut state = State {
+            position: Position::InCopy {
+                current_table: CurrentTableTransforms {
+                    table_name: "public.users".to_string(),
+                    columns: vec![
+                        ColumnInfo::builder()
+                            .with_name("column_1")
+                            .with_transformer(TransformerType::Identity, None)
+                            .build(),
+                        ColumnInfo::builder()
+                            .with_name("column_2")
+                            .with_transformer(TransformerType::Identity, None)
+                            .build(),
+                        ColumnInfo::builder()
+                            .with_name("column_3")
+                            .with_transformer(TransformerType::Identity, None)
+                            .build(),
+                    ],
+                },
+            },
+            types: Types::builder()
+                .add_type("public.users", "column_1", SubType::Character)
+                .add_type("public.users", "column_2", SubType::Character)
+                .add_type("public.users", "column_3", SubType::Character)
+                .build(),
+        };
+        let mut rng = rng::get();
+        let transformed_row = parse(&mut rng, table_data_row, &mut state, &strategies);
+        assert_eq!(table_data_row, transformed_row);
     }
 
     #[test]


### PR DESCRIPTION
Heya y'all

found a bug where if a table row had whitespace at the start / end it would be removed!

we trim the row, then used the trimmed row for transformations, but actually when transforming we should use the original line, because the ACTUAL DATA can have whitespace!

we only need to trim for lines that can be indented just so we can identify them but the first non whitespace chars