### PR TITLE
Add truncate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,23 @@ The following data categories are supported
 - Unknown - Unclassified, If any fields have this anonymisation will fail until it is replaced with a valid type
 
 
-## Transformers
+## Data transformation
+
+Table data can be transformed in one of two ways,
+1. Truncating the table
+To use this option the table should be defined in the strategy file with the `truncate` key set to `true` and the `columns` key set to an empty array. e.g.
+  ```
+   {
+    "table_name": "public.trunctable_table",
+    "description": "",
+    "truncate": true,
+    "columns": []
+  },
+  ```
+
+2. Transform the data in the table
+Transforming table data requires a list of all table columns with a transformer defined for each and every column. (Note that for non PII or sensitive data, you can use the `Identity` transformer to not transform the data.
+
 - EmptyJson - Literally `{}`
 - Error - Not set. If any fields have this anonymisation will fail until it is replaced with a valid transformer
 - FakeBase16String - Random Base16 string

--- a/src/anonymiser.rs
+++ b/src/anonymiser.rs
@@ -83,13 +83,13 @@ mod tests {
         let postgres = format!("{}/postgres", db_url);
         let mut conn = Client::connect(&postgres, NoTls).expect("expected connection to succeed");
 
-        conn.simple_query("drop database if exists anonymiser_test")
+        conn.simple_query("drop database if exists successfully_transforms_test_db")
             .unwrap();
-        conn.simple_query("create database anonymiser_test")
+        conn.simple_query("create database successfully_transforms_test_db")
             .unwrap();
 
         let result = Command::new("psql")
-            .arg(format!("{}/anonymiser_test", db_url))
+            .arg(format!("{}/successfully_transforms_test_db", db_url))
             .arg("-f")
             .arg("test_files/results.sql")
             .arg("-v")
@@ -119,13 +119,15 @@ mod tests {
         let postgres = format!("{}/postgres", db_url);
         let mut conn = Client::connect(&postgres, NoTls).expect("expected connection to succeed");
 
-        conn.simple_query("drop database if exists anonymiser_test")
+        conn.simple_query("drop database if exists successfully_truncates_db_name")
             .unwrap();
-        conn.simple_query("create database anonymiser_test")
+        conn.simple_query("create database successfully_truncates_db_name")
             .unwrap();
 
+        conn.close().expect("expected connection to close");
+
         let result = Command::new("psql")
-            .arg(format!("{}/anonymiser_test", db_url))
+            .arg(format!("{}/successfully_truncates_db_name", db_url))
             .arg("-f")
             .arg("test_files/results.sql")
             .arg("-v")
@@ -138,5 +140,16 @@ mod tests {
             "failed to restore backup:\n{:?}",
             String::from_utf8(result.stderr).unwrap()
         );
+
+        let test_db = format!("{}/successfully_truncates_db_name", db_url);
+        let mut test_db_conn =
+            Client::connect(&test_db, NoTls).expect("expected connection to succeed");
+
+        let extra_data_row_count: i64 = test_db_conn
+            .query_one("select count(*) from extra_data", &[])
+            .unwrap()
+            .get(0);
+
+        assert_eq!(extra_data_row_count, 0);
     }
 }

--- a/src/anonymiser.rs
+++ b/src/anonymiser.rs
@@ -70,9 +70,10 @@ mod tests {
 
     #[test]
     fn successfully_transforms() {
+        let result_file_name = "test_files/results_successfully_transforms.sql";
         assert!(anonymise(
             "test_files/dump_file.sql".to_string(),
-            "test_files/results.sql".to_string(),
+            result_file_name.to_string(),
             "test_files/strategy.json".to_string(),
             None,
             TransformerOverrides::none(),
@@ -91,7 +92,7 @@ mod tests {
         let result = Command::new("psql")
             .arg(format!("{}/successfully_transforms_test_db", db_url))
             .arg("-f")
-            .arg("test_files/results.sql")
+            .arg(result_file_name)
             .arg("-v")
             .arg("ON_ERROR_STOP=1")
             .output()

--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -98,6 +98,12 @@ mod tests {
                 strategy_tuple("phone_number"),
             ]),
         );
+
+        strategies.insert(
+            "public.extra_data".to_string(),
+            HashMap::from([strategy_tuple("id"), strategy_tuple("data")]),
+        );
+
         strategies
     }
 

--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -129,7 +129,8 @@ mod tests {
     fn can_read_and_output_compressed_with_default() {
         let input_file = "test_files/dump_file.sql".to_string();
         let compressed_file = "test_files/compressed_file_reader_test_results.sql".to_string();
-        let uncompressed_file_name = "test_files/uncompressed_file_reader_test_results.sql";
+        let uncompressed_file_name =
+            "test_files/uncompressed_file_reader_can_read_and_output_compressed_with_default.sql";
 
         let _ = fs::remove_file(&compressed_file);
         let _ = fs::remove_file(uncompressed_file_name);
@@ -162,7 +163,7 @@ mod tests {
     fn can_read_and_output_compressed_with_specific_compression_type() {
         let input_file = "test_files/dump_file.sql".to_string();
         let compressed_file = "test_files/compressed_file_reader_test_results.sql".to_string();
-        let uncompressed_file_name = "test_files/uncompressed_file_reader_test_results.sql";
+        let uncompressed_file_name = "test_files/uncompressed_file_reader_can_read_and_output_compressed_with_sepcific_compression_type.sql";
 
         let _ = fs::remove_file(&compressed_file);
         let _ = fs::remove_file(uncompressed_file_name);

--- a/src/fixers/db_mismatch.rs
+++ b/src/fixers/db_mismatch.rs
@@ -32,6 +32,7 @@ fn add_missing(current: Vec<StrategyInFile>, missing: &[SimpleColumn]) -> Vec<St
             }
             None => {
                 let mut new_table = StrategyInFile {
+                    truncate: false,
                     table_name: table.clone(),
                     description: "".to_string(),
                     columns: vec![],
@@ -95,6 +96,7 @@ mod tests {
         let current = vec![StrategyInFile {
             table_name: "public.person".to_string(),
             description: "".to_string(),
+            truncate: false,
             columns: vec![ColumnInFile::new("id"), ColumnInFile::new("first_name")],
         }];
 
@@ -119,6 +121,7 @@ mod tests {
             StrategyInFile {
                 table_name: "public.person".to_string(),
                 description: "".to_string(),
+                truncate: false,
                 columns: vec![
                     ColumnInFile::new("id"),
                     ColumnInFile::new("first_name"),
@@ -128,6 +131,7 @@ mod tests {
             StrategyInFile {
                 table_name: "public.location".to_string(),
                 description: "".to_string(),
+                truncate: false,
                 columns: vec![ColumnInFile::new("id"), ColumnInFile::new("post_code")],
             },
         ];
@@ -141,11 +145,13 @@ mod tests {
             StrategyInFile {
                 table_name: "public.location".to_string(),
                 description: "".to_string(),
+                truncate: false,
                 columns: vec![ColumnInFile::new("id"), ColumnInFile::new("post_code")],
             },
             StrategyInFile {
                 table_name: "public.person".to_string(),
                 description: "".to_string(),
+                truncate: false,
                 columns: vec![
                     ColumnInFile::new("id"),
                     ColumnInFile::new("first_name"),
@@ -174,6 +180,7 @@ mod tests {
         let expected = vec![StrategyInFile {
             table_name: "public.person".to_string(),
             description: "".to_string(),
+            truncate: false,
             columns: vec![ColumnInFile::new("id"), ColumnInFile::new("first_name")],
         }];
 

--- a/src/parsers/copy_row.rs
+++ b/src/parsers/copy_row.rs
@@ -1,7 +1,6 @@
 use crate::parsers::sanitiser;
 use crate::parsers::strategies::Strategies;
 use crate::parsers::strategies::TableStrategy;
-use crate::parsers::strategy_structs::ColumnInfo;
 use lazy_static::lazy_static;
 use regex::Regex;
 

--- a/src/parsers/copy_row.rs
+++ b/src/parsers/copy_row.rs
@@ -115,8 +115,7 @@ mod tests {
             .iter()
             .map(|column| (column.name.clone(), column.clone()))
             .collect();
-        let strategies =
-            Strategies::new_from("public.users".to_string(), column_infos_with_name.clone());
+        let strategies = Strategies::new_from("public.users".to_string(), column_infos_with_name);
         let parsed_copy_row = parse(
             "COPY public.users (id, first_name, last_name) FROM stdin;\n",
             &strategies,

--- a/src/parsers/copy_row.rs
+++ b/src/parsers/copy_row.rs
@@ -47,8 +47,6 @@ fn get_current_table_information(
         .split(", ")
         .map(sanitiser::dequote_column_or_table_name_data)
         .collect();
-    println!("column_name_list: {:?}", column_name_list);
-    println!("strategies: {:?}", strategies);
     let table_transformers = table_strategy(strategies, &table_name, &column_name_list);
 
     CurrentTableTransforms {
@@ -64,8 +62,6 @@ fn table_strategy(
 ) -> TableTransformers {
     let strategies_for_table = strategies.for_table(table_name);
 
-    println!("Strategies for table: {:?}", strategies_for_table);
-    println!("Column name list: {:?}", column_name_list);
     match strategies_for_table {
         Some(TableStrategy::Columns(columns_with_names)) => {
             let column_infos = column_name_list

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -468,7 +468,7 @@ mod tests {
             position: Position::InCopy {
                 current_table: CurrentTableTransforms {
                     table_name: "public.users".to_string(),
-                    columns: vec![
+                    table_transformers: TableTransformers::ColumnTransformer(vec![
                         ColumnInfo::builder()
                             .with_name("column_1")
                             .with_transformer(TransformerType::Identity, None)
@@ -481,7 +481,7 @@ mod tests {
                             .with_name("column_3")
                             .with_transformer(TransformerType::Identity, None)
                             .build(),
-                    ],
+                    ]),
                 },
             },
             types: Types::builder()

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -147,6 +147,7 @@ fn add_create_table_row_to_types(line: &str, mut current_types: Vec<Column>) -> 
 mod tests {
     use super::*;
     use crate::parsers::rng;
+    use crate::parsers::strategies::TableStrategy;
     use crate::parsers::strategy_structs::{ColumnInfo, DataCategory, TransformerType};
     use crate::parsers::types::{SubType, Type};
     use std::collections::HashMap;
@@ -309,8 +310,9 @@ mod tests {
 
         match state.position {
             Position::InCopy { current_table } => {
-                let expected_columns = vec![id_column, first_name_column, last_name_column];
-                assert_eq!(expected_columns, current_table.columns)
+                let expected_columns =
+                    TableStrategy::Columns(vec![id_column, first_name_column, last_name_column]);
+                assert_eq!(expected_columns, current_table.table_strategy)
             }
             _other => unreachable!("Position is not InCopy!"),
         };
@@ -375,11 +377,11 @@ mod tests {
             position: Position::InCopy {
                 current_table: CurrentTableTransforms {
                     table_name: "public.users".to_string(),
-                    columns: vec![
+                    table_strategy: TableStrategy::Columns(vec![
                         ColumnInfo::builder().with_name("column_1").build(),
                         ColumnInfo::builder().with_name("column_2").build(),
                         ColumnInfo::builder().with_name("column_3").build(),
-                    ],
+                    ]),
                 },
             },
             types: Types::builder()
@@ -402,7 +404,7 @@ mod tests {
             position: Position::InCopy {
                 current_table: CurrentTableTransforms {
                     table_name: "public.users".to_string(),
-                    columns: vec![
+                    table_strategy: TableStrategy::Columns(vec![
                         ColumnInfo::builder()
                             .with_name("column_1")
                             .with_transformer(
@@ -424,7 +426,7 @@ mod tests {
                                 Some(HashMap::from([("value".to_string(), "third".to_string())])),
                             )
                             .build(),
-                    ],
+                    ]),
                 },
             },
             types: Types::builder()

--- a/src/parsers/state.rs
+++ b/src/parsers/state.rs
@@ -78,6 +78,7 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::strategies::TableStrategy;
     use crate::parsers::types::Column;
     use std::collections::HashMap;
 
@@ -94,7 +95,7 @@ mod tests {
         let new_position = Position::InCopy {
             current_table: CurrentTableTransforms {
                 table_name: "table-mc-tableface".to_string(),
-                columns: Vec::new(),
+                table_strategy: TableStrategy::Columns(HashMap::from([])),
             },
         };
 

--- a/src/parsers/state.rs
+++ b/src/parsers/state.rs
@@ -78,7 +78,7 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parsers::strategies::TableStrategy;
+    use crate::parsers::copy_row::TableTransformers;
     use crate::parsers::types::Column;
     use std::collections::HashMap;
 
@@ -95,7 +95,7 @@ mod tests {
         let new_position = Position::InCopy {
             current_table: CurrentTableTransforms {
                 table_name: "table-mc-tableface".to_string(),
-                table_strategy: TableStrategy::Columns(HashMap::from([])),
+                table_transformers: TableTransformers::ColumnTransformer(vec![]),
             },
         };
 

--- a/src/parsers/strategies.rs
+++ b/src/parsers/strategies.rs
@@ -102,13 +102,10 @@ impl Strategies {
         self.tables.insert(table_name, TableStrategy::Truncate)
     }
 
-    // TODO here, we need to work out how to do validation for tuncation
     pub fn validate_against_db(
         &self,
         columns_from_db: HashSet<SimpleColumn>,
     ) -> Result<(), DbErrors> {
-        // from self, split into 2 groups, one for tables, one for truncate
-
         let (columns_by_table, truncate): (Vec<(String, ColumnNamesToInfo)>, Vec<_>) = self
             .tables
             .clone()

--- a/src/parsers/strategies.rs
+++ b/src/parsers/strategies.rs
@@ -280,6 +280,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: TABLE_NAME.to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![column_in_file(
                 DataCategory::Pii,
                 column_name,
@@ -314,16 +315,19 @@ mod tests {
             StrategyInFile {
                 table_name: TABLE_NAME.to_string(),
                 description: "description".to_string(),
+                truncate: false,
                 columns: vec![],
             },
             StrategyInFile {
                 table_name: TABLE_NAME.to_string(),
                 description: "description".to_string(),
+                truncate: false,
                 columns: vec![],
             },
             StrategyInFile {
                 table_name: table2_name.to_string(),
                 description: "description".to_string(),
+                truncate: false,
                 columns: vec![duplicated_column.clone(), duplicated_column],
             },
         ];
@@ -343,6 +347,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: "public.person".to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![column_in_file(
                 DataCategory::Unknown,
                 "first_name",
@@ -364,6 +369,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: "public.person".to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![column_in_file(
                 DataCategory::General,
                 "first_name",
@@ -385,6 +391,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: "public.person".to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![
                 column_in_file(DataCategory::Pii, "first_name", TransformerType::Identity),
                 column_in_file(
@@ -413,6 +420,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: TABLE_NAME.to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![
                 column_in_file(
                     DataCategory::PotentialPii,
@@ -455,6 +463,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: TABLE_NAME.to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![
                 column_in_file(
                     DataCategory::PotentialPii,
@@ -498,6 +507,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: TABLE_NAME.to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![column_in_file(
                 DataCategory::General,
                 SCRAMBLED_COLUMN_NAME,
@@ -524,6 +534,7 @@ mod tests {
         let strategies = vec![StrategyInFile {
             table_name: TABLE_NAME.to_string(),
             description: "description".to_string(),
+            truncate: false,
             columns: vec![
                 column_in_file(
                     DataCategory::PotentialPii,

--- a/src/parsers/strategies.rs
+++ b/src/parsers/strategies.rs
@@ -10,12 +10,12 @@ pub struct Strategies {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TableStrategy {
-    Columns(HashMap<String, ColumnInfo>),
+    Columns(Vec<ColumnInfo>),
     Truncate,
 }
 
 impl TableStrategy {
-    fn to_columns(self) -> HashMap<String, ColumnInfo> {
+    fn to_columns(self) -> Vec<ColumnInfo> {
         if let TableStrategy::Columns(c) = self {
             c
         } else {
@@ -96,7 +96,7 @@ impl Strategies {
     pub fn insert(
         &mut self,
         table_name: String,
-        columns: HashMap<String, ColumnInfo>,
+        columns: Vec<ColumnInfo>,
     ) -> Option<TableStrategy> {
         self.tables
             .insert(table_name, TableStrategy::Columns(columns))

--- a/src/parsers/strategies.rs
+++ b/src/parsers/strategies.rs
@@ -315,6 +315,19 @@ mod tests {
         assert_eq!(Ok(()), result);
     }
 
+    #[test]
+    fn validates_missing_entire_table() {
+        let strategies = Strategies::new();
+
+        let columns_from_db = HashSet::from([create_simple_column("public.location", "postcode")]);
+        let error = strategies.validate_against_db(columns_from_db).unwrap_err();
+
+        assert_eq!(
+            error.missing_from_strategy_file,
+            vec!(create_simple_column("public.location", "postcode"))
+        );
+    }
+
     const TABLE_NAME: &str = "gert_lush_table";
     const PII_COLUMN_NAME: &str = "pii_column";
     const COMMERCIALLY_SENSITIVE_COLUMN_NAME: &str = "commercially_sensitive_column";

--- a/src/parsers/strategy_errors.rs
+++ b/src/parsers/strategy_errors.rs
@@ -29,7 +29,7 @@ impl From<DbErrors> for StrategyFileError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DbErrors {
     pub missing_from_strategy_file: Vec<SimpleColumn>,
     pub missing_from_db: Vec<SimpleColumn>,

--- a/src/parsers/strategy_file.rs
+++ b/src/parsers/strategy_file.rs
@@ -15,6 +15,7 @@ pub fn read(file_name: &str) -> Result<Vec<StrategyInFile>, std::io::Error> {
         })
     });
 
+    println!("{:?}", result);
     match result {
         Ok(_) => result,
         Err(ref err) => match err.kind() {

--- a/src/parsers/strategy_file.rs
+++ b/src/parsers/strategy_file.rs
@@ -15,7 +15,6 @@ pub fn read(file_name: &str) -> Result<Vec<StrategyInFile>, std::io::Error> {
         })
     });
 
-    println!("{:?}", result);
     match result {
         Ok(_) => result,
         Err(ref err) => match err.kind() {

--- a/src/parsers/strategy_structs.rs
+++ b/src/parsers/strategy_structs.rs
@@ -47,6 +47,10 @@ impl PartialEq for ColumnInFile {
 pub struct StrategyInFile {
     pub table_name: String,
     pub description: String,
+
+    #[serde(default)]
+    pub truncate: bool,
+
     pub columns: Vec<ColumnInFile>,
 }
 

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -1037,7 +1037,6 @@ mod tests {
             },
             TABLE_NAME,
         );
-        println!("{new_value}");
         assert!(new_value != initial_value);
         assert!(!new_value.contains("Second line"));
         assert!(!new_value.contains("Third line"));

--- a/src/test_builders.rs
+++ b/src/test_builders.rs
@@ -81,6 +81,7 @@ pub mod builders {
         pub fn build(self) -> StrategyInFile {
             StrategyInFile {
                 table_name: self.table_name,
+                truncate: false,
                 description: self
                     .description
                     .unwrap_or_else(|| "Any description".to_string()),

--- a/test_files/dump_file.sql
+++ b/test_files/dump_file.sql
@@ -44,6 +44,29 @@ ALTER TABLE public.orders ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
     CACHE 1
 );
 
+--
+-- Name: extra_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.extra_data (
+    id bigint NOT NULL,
+    data character varying(255) NOT NULL,
+);
+
+--
+-- Name: extra_data_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.extra_data ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.extra_data_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
 
 --
 -- Name: products; Type: TABLE; Schema: public; Owner: -
@@ -120,6 +143,18 @@ COPY public.orders (id, user_id, product_id) FROM stdin;
 8	5	2
 \.
 
+--
+-- Data for Name: extra_data; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.extra_data (id, user_id, product_id) FROM stdin;
+1	this is jank
+2	more jank
+3	another line of jank
+4	yuk, not more jank!
+5	you guess it.
+\.
+
 
 --
 -- Data for Name: products; Type: TABLE DATA; Schema: public; Owner: -
@@ -154,6 +189,12 @@ COPY public.users (id, email, password, last_login, inserted_at, updated_at, fir
 
 SELECT pg_catalog.setval('public.orders_id_seq', 8, true);
 
+--
+-- Name: extra_data_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.extra_data_id_seq', 5, true);
+
 
 --
 -- Name: products_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
@@ -175,6 +216,13 @@ SELECT pg_catalog.setval('public.users_id_seq', 7, true);
 
 ALTER TABLE ONLY public.orders
     ADD CONSTRAINT orders_pkey PRIMARY KEY (id);
+
+--
+-- Name: extra_data extra_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extra_data
+    ADD CONSTRAINT extra_data_pkey PRIMARY KEY (id);
 
 
 --

--- a/test_files/dump_file.sql
+++ b/test_files/dump_file.sql
@@ -152,7 +152,7 @@ COPY public.extra_data (id, data) FROM stdin;
 2	more jank
 3	another line of jank
 4	yuk, not more jank!
-5	you guess it.
+5	you guessed it.
 \.
 
 --

--- a/test_files/dump_file.sql
+++ b/test_files/dump_file.sql
@@ -50,7 +50,7 @@ ALTER TABLE public.orders ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
 
 CREATE TABLE public.extra_data (
     id bigint NOT NULL,
-    data character varying(255) NOT NULL,
+    data character varying(255) NOT NULL
 );
 
 --
@@ -147,14 +147,13 @@ COPY public.orders (id, user_id, product_id) FROM stdin;
 -- Data for Name: extra_data; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-COPY public.extra_data (id, user_id, product_id) FROM stdin;
+COPY public.extra_data (id, data) FROM stdin;
 1	this is jank
 2	more jank
 3	another line of jank
 4	yuk, not more jank!
 5	you guess it.
 \.
-
 
 --
 -- Data for Name: products; Type: TABLE DATA; Schema: public; Owner: -

--- a/test_files/strategy.json
+++ b/test_files/strategy.json
@@ -1,5 +1,11 @@
 [
   {
+    "table_name": "public.extra_data",
+    "description": "",
+    "truncate": true,
+    "columns": []
+  },
+  {
     "table_name": "public.orders",
     "description": "",
     "columns": [


### PR DESCRIPTION
Adds an option to truncate a table!

The intent here is that for some tables (e.g. oban_jobs in our situation) we don't want any of the data from that table in our anonymised dump because its large and / or irrelevant for our purposes. The table is still created, with the same shape and config, but there is no row data in it

In the case of truncation. defining a list of columns felt a bit unnecessary as you're dropping all the data so transformers for each column don't make sense.

In order to achieve that, this pr adds a wrapper around the transformers, called `CurrentTableTransforms` which carries either the list of columns or the truncate action

Setting up the data structure occurs [here](https://github.com/Multiverse-io/anonymiser/pull/163/files#diff-c7b6c38a3c3db9ad45d1ca13fc129931e4527fde5ebf1348ca1447aa9dfd75d3R35), if the strategy has the `truncate` flag set, we just add the Truncator transform type, otherwise we do what we did previously, which is to build a list of transformers for the columns

The main action here is [here](https://github.com/Multiverse-io/anonymiser/pull/163/files#diff-d2df7f344426ad1c4e8e40224e02b2ad6b3495c750f4758e191e1154a4cdaf69R111). when parsing a data row, if the table transform is the Truncator, we always return an empty string rather than transforming the row with the transform list.

There are tests at the unit level and also at the giant top level tests that use a real sql file and test the results

