### PR TITLE
Add salt to hashing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,24 @@ When using deterministic mode:
 - Different IDs will generate different names, even for the same input value
 
 This is useful when you need consistent fake names across multiple database dumps or when maintaining referential integrity between tables.
+
+## Global Salt
+
+The anonymiser supports using a global salt for consistent hashing across different runs. To use this feature, add a salt configuration as the first item in your strategy.json file:
+
+```json
+[
+  {
+    "salt": "your-global-salt-here"
+  },
+  {
+    "table_name": "public.users",
+    "description": "",
+    "columns": [
+      // ... columns configuration ...
+    ]
+  }
+]
+```
+
+The salt will be applied to all transformers that support salted hashing (marked with † in the transformer list). Different salt values will generate different outputs for the same input

--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -71,6 +71,7 @@ mod tests {
                 strategy_tuple("user_id"),
                 strategy_tuple("product_id"),
             ]),
+            None,
         );
         strategies.insert(
             "public.products".to_string(),
@@ -81,6 +82,7 @@ mod tests {
                 strategy_tuple("details"),
                 strategy_tuple("tags"),
             ]),
+            None,
         );
 
         strategies.insert(
@@ -97,11 +99,13 @@ mod tests {
                 strategy_tuple("deactivated"),
                 strategy_tuple("phone_number"),
             ]),
+            None,
         );
 
         strategies.insert(
             "public.extra_data".to_string(),
             HashMap::from([strategy_tuple("id"), strategy_tuple("data")]),
+            None,
         );
 
         strategies

--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -71,7 +71,6 @@ mod tests {
                 strategy_tuple("user_id"),
                 strategy_tuple("product_id"),
             ]),
-            None,
         );
         strategies.insert(
             "public.products".to_string(),
@@ -82,7 +81,6 @@ mod tests {
                 strategy_tuple("details"),
                 strategy_tuple("tags"),
             ]),
-            None,
         );
 
         strategies.insert(
@@ -99,13 +97,11 @@ mod tests {
                 strategy_tuple("deactivated"),
                 strategy_tuple("phone_number"),
             ]),
-            None,
         );
 
         strategies.insert(
             "public.extra_data".to_string(),
             HashMap::from([strategy_tuple("id"), strategy_tuple("data")]),
-            None,
         );
 
         strategies

--- a/src/fixers/db_mismatch.rs
+++ b/src/fixers/db_mismatch.rs
@@ -39,6 +39,7 @@ fn add_missing(current: Vec<StrategyInFile>, missing: &[SimpleColumn]) -> Vec<St
                     table_name: table.clone(),
                     description: "".to_string(),
                     columns: vec![],
+                    salt: None,
                 };
                 for column in missing_columns {
                     new_table.columns.push(ColumnInFile::new(&column));
@@ -102,6 +103,7 @@ mod tests {
             description: "".to_string(),
             truncate: false,
             columns: vec![ColumnInFile::new("id"), ColumnInFile::new("first_name")],
+            salt: None,
         }];
 
         let missing = vec![
@@ -131,12 +133,14 @@ mod tests {
                     ColumnInFile::new("first_name"),
                     ColumnInFile::new("last_name"),
                 ],
+                salt: None,
             },
             StrategyInFile {
                 table_name: "public.location".to_string(),
                 description: "".to_string(),
                 truncate: false,
                 columns: vec![ColumnInFile::new("id"), ColumnInFile::new("post_code")],
+                salt: None,
             },
         ];
 
@@ -151,6 +155,7 @@ mod tests {
                 description: "".to_string(),
                 truncate: false,
                 columns: vec![ColumnInFile::new("id"), ColumnInFile::new("post_code")],
+                salt: None,
             },
             StrategyInFile {
                 table_name: "public.person".to_string(),
@@ -161,6 +166,7 @@ mod tests {
                     ColumnInFile::new("first_name"),
                     ColumnInFile::new("last_name"),
                 ],
+                salt: None,
             },
         ];
 
@@ -186,6 +192,7 @@ mod tests {
             description: "".to_string(),
             truncate: false,
             columns: vec![ColumnInFile::new("id"), ColumnInFile::new("first_name")],
+            salt: None,
         }];
 
         assert_eq!(result, expected);

--- a/src/parsers/copy_row.rs
+++ b/src/parsers/copy_row.rs
@@ -68,7 +68,7 @@ fn table_strategy(
     let strategies_for_table = strategies.for_table(table_name);
 
     match strategies_for_table {
-        Some(TableStrategy::Columns(columns_with_names, _)) => {
+        Some(TableStrategy::Columns(columns_with_names)) => {
             let column_infos = column_name_list
                 .iter()
                 .map(|column_name| match columns_with_names.get(column_name) {
@@ -116,7 +116,14 @@ mod tests {
             .iter()
             .map(|column| (column.name.clone(), column.clone()))
             .collect();
-        let strategies = Strategies::new_from("public.users".to_string(), column_infos_with_name);
+
+        let test_salt = "test_table_salt".to_string();
+        let strategies = Strategies::new_from_with_salt(
+            "public.users".to_string(),
+            column_infos_with_name,
+            Some(test_salt.clone()),
+        );
+
         let parsed_copy_row = parse(
             "COPY public.users (id, first_name, last_name) FROM stdin;\n",
             &strategies,
@@ -125,7 +132,7 @@ mod tests {
         let expected = CurrentTableTransforms {
             table_name: "public.users".to_string(),
             table_transformers: TableTransformers::ColumnTransformer(columns),
-            salt: None,
+            salt: Some(test_salt),
         };
 
         assert_eq!(expected.table_name, parsed_copy_row.table_name);

--- a/src/parsers/copy_row.rs
+++ b/src/parsers/copy_row.rs
@@ -9,6 +9,7 @@ use regex::Regex;
 pub struct CurrentTableTransforms {
     pub table_name: String,
     pub table_transformers: TableTransformers,
+    pub salt: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -27,9 +28,11 @@ pub fn parse(copy_row: &str, strategies: &Strategies) -> CurrentTableTransforms 
         let some_table = capture_to_item(&cap, "table");
         match (some_table, some_columns) {
             (Some(table), Some(unsplit_columns)) => {
-                get_current_table_information(table, unsplit_columns, strategies)
+                let mut current_table =
+                    get_current_table_information(table, unsplit_columns, strategies);
+                current_table.salt = strategies.salt_for_table(table).map(String::from);
+                current_table
             }
-
             (_, _) => panic!("Invalid Copy row format: {:?}", copy_row),
         }
     } else {
@@ -48,10 +51,12 @@ fn get_current_table_information(
         .map(sanitiser::dequote_column_or_table_name_data)
         .collect();
     let table_transformers = table_strategy(strategies, &table_name, &column_name_list);
+    let salt = strategies.salt_for_table(&table_name).map(String::from);
 
     CurrentTableTransforms {
         table_name,
         table_transformers,
+        salt,
     }
 }
 
@@ -63,7 +68,7 @@ fn table_strategy(
     let strategies_for_table = strategies.for_table(table_name);
 
     match strategies_for_table {
-        Some(TableStrategy::Columns(columns_with_names)) => {
+        Some(TableStrategy::Columns(columns_with_names, _)) => {
             let column_infos = column_name_list
                 .iter()
                 .map(|column_name| match columns_with_names.get(column_name) {
@@ -120,6 +125,7 @@ mod tests {
         let expected = CurrentTableTransforms {
             table_name: "public.users".to_string(),
             table_transformers: TableTransformers::ColumnTransformer(columns),
+            salt: None,
         };
 
         assert_eq!(expected.table_name, parsed_copy_row.table_name);
@@ -127,6 +133,7 @@ mod tests {
             expected.table_transformers,
             parsed_copy_row.table_transformers
         );
+        assert_eq!(expected.salt, parsed_copy_row.salt);
     }
 
     #[test]
@@ -150,6 +157,7 @@ mod tests {
             expected_table_transformers,
             parsed_copy_row.table_transformers
         );
+        assert_eq!(None, parsed_copy_row.salt);
     }
 
     #[test]

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -104,9 +104,14 @@ fn transform_row(
     types: &Types,
 ) -> String {
     match current_table.table_transformers {
-        TableTransformers::ColumnTransformer(ref columns) => {
-            transform_row_with_columns(rng, line, &current_table.table_name, columns, types)
-        }
+        TableTransformers::ColumnTransformer(ref columns) => transform_row_with_columns(
+            rng,
+            line,
+            &current_table.table_name,
+            columns,
+            types,
+            current_table.salt.as_deref(),
+        ),
 
         TableTransformers::Truncator => "".to_string(),
     }
@@ -118,6 +123,7 @@ fn transform_row_with_columns(
     table_name: &str,
     columns: &[ColumnInfo],
     types: &Types,
+    salt: Option<&str>,
 ) -> String {
     let column_values: Vec<String> = data_row::split(line).map(|s| s.to_string()).collect();
 
@@ -151,6 +157,7 @@ fn transform_row_with_columns(
             &current_column.transformer,
             table_name,
             &column_name_values,
+            salt,
         )
     });
 
@@ -410,6 +417,7 @@ mod tests {
                         ColumnInfo::builder().with_name("column_2").build(),
                         ColumnInfo::builder().with_name("column_3").build(),
                     ]),
+                    salt: None,
                 },
             },
             types: Types::builder()
@@ -455,6 +463,7 @@ mod tests {
                             )
                             .build(),
                     ]),
+                    salt: None,
                 },
             },
             types: Types::builder()
@@ -490,6 +499,7 @@ mod tests {
                             .with_transformer(TransformerType::Identity, None)
                             .build(),
                     ]),
+                    salt: None,
                 },
             },
             types: Types::builder()
@@ -518,6 +528,7 @@ mod tests {
                             .with_transformer(TransformerType::Scramble, None)
                             .build(),
                     ]),
+                    salt: None,
                 },
             },
             types: Types::builder()

--- a/src/parsers/state.rs
+++ b/src/parsers/state.rs
@@ -96,6 +96,7 @@ mod tests {
             current_table: CurrentTableTransforms {
                 table_name: "table-mc-tableface".to_string(),
                 table_transformers: TableTransformers::ColumnTransformer(vec![]),
+                salt: None,
             },
         };
 

--- a/src/parsers/strategy_structs.rs
+++ b/src/parsers/strategy_structs.rs
@@ -51,6 +51,9 @@ pub struct StrategyInFile {
     #[serde(default)]
     pub truncate: bool,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub salt: Option<String>,
+
     pub columns: Vec<ColumnInFile>,
 }
 

--- a/src/parsers/strategy_structs.rs
+++ b/src/parsers/strategy_structs.rs
@@ -45,7 +45,10 @@ impl PartialEq for ColumnInFile {
 
 #[derive(Clone, Debug, Eq, Serialize, Deserialize)]
 pub struct StrategyInFile {
+    #[serde(default)]
     pub table_name: String,
+
+    #[serde(default)]
     pub description: String,
 
     #[serde(default)]
@@ -54,6 +57,7 @@ pub struct StrategyInFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub salt: Option<String>,
 
+    #[serde(default)]
     pub columns: Vec<ColumnInFile>,
 }
 
@@ -166,4 +170,9 @@ impl Default for TransformerOverrides {
     fn default() -> Self {
         Self::none()
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SaltConfig {
+    pub salt: String,
 }

--- a/src/test_builders.rs
+++ b/src/test_builders.rs
@@ -59,6 +59,7 @@ pub mod builders {
         table_name: String,
         description: Option<String>,
         columns: Vec<ColumnInFile>,
+        salt: Option<String>,
     }
 
     impl StrategyInFile {
@@ -85,7 +86,7 @@ pub mod builders {
                 description: self
                     .description
                     .unwrap_or_else(|| "Any description".to_string()),
-                salt: None,
+                salt: self.salt,
                 columns: self.columns,
             }
         }

--- a/src/test_builders.rs
+++ b/src/test_builders.rs
@@ -85,6 +85,7 @@ pub mod builders {
                 description: self
                     .description
                     .unwrap_or_else(|| "Any description".to_string()),
+                salt: None,
                 columns: self.columns,
             }
         }


### PR DESCRIPTION
# Add Global Salt to Hashing Logic

## Overview
This PR implements a global salt mechanism for the anonymisation process. The salt is specified in the strategy.json file and is applied consistently across all hashing operations.

## Implementation Details
- Added support for reading a global salt from strategy.json
- The salt configuration must be the first item in the strategy file array
- Modified the transformer logic to incorporate salt in hashing operations
- Updated tests to verify salt functionality

## Strategy File Format
The strategy.json file should now follow this structure:
```json
[
  {
    "salt": "global-salt-here"
  },
  {
    "table_name": "public.registrations",
    "description": "",
    "columns": [
      // ... existing columns ...
    ]
  },
  // ... rest of the tables ...
]
```

## Important Notes
- The salt configuration must be the first item in the array
- The salt is applied globally to all tables that require hashing
- No salt (or empty salt configuration) will maintain existing behavior

## Test Steps
- [ ] create test db and test anonymizer db: `createdb test_anonymiser_db` and `createdb anonymized_db`
- [ ] create sql file `test_db.sql` and add the following. (add email and company if needed)
```
CREATE TABLE public.users (
    user_id SERIAL,
    account_id VARCHAR(255),
    customer_id VARCHAR(255),
    first_name VARCHAR(255),
    last_name VARCHAR(255),
    full_name VARCHAR(255)
);

INSERT INTO public.users (user_id, account_id, customer_id, first_name, last_name, full_name) VALUES 
    (1, 'ACC_001', 'CUST_001', 'John', 'Smith', 'John Smith'),
    (2, 'ACC_001', 'CUST_002', 'John', 'Brown', 'John Brown'),
    (3, 'ACC_002', 'CUST_001', 'Mary', 'Smith', 'Mary Smith'),
    (1, 'ACC_003', 'CUST_003', 'John', 'Smith', 'John Smith');

-- View the original data
SELECT * FROM public.users;
```
- [] populate test db with the data from the sql file: `psql test_anonymiser_db < test_db.sql`
- [] update strategy.json or create new strategy with salt
```
[
    {
       "salt": "global-test-salt"
    },
    {
      "table_name": "public.users",
      "description": "User table for testing",
      "truncate": false,
      "columns": [
        {
          "name": "user_id",
          "data_category": "General",
          "description": "User identifier",
          "transformer": {
            "name": "Identity"
          }
        },
        {
          "name": "account_id",
          "data_category": "General",
          "description": "Account identifier",
          "transformer": {
            "name": "Identity"
          }
        },
        {
          "name": "customer_id",
          "data_category": "General",
          "description": "Customer identifier",
          "transformer": {
            "name": "Identity"
          }
        },
        {
          "name": "first_name",
          "data_category": "Pii",
          "description": "User's first name",
          "transformer": {
            "name": "FakeFirstName",
            "args": {
              "deterministic": "true",
              "id_column": "user_id"
            }
          }
        },
        {
          "name": "last_name",
          "data_category": "Pii",
          "description": "User's last name",
          "transformer": {
            "name": "FakeLastName",
            "args": {
              "deterministic": "true",
              "id_column": "user_id"
            }
          }
        },
        {
          "name": "full_name",
          "data_category": "Pii",
          "description": "User's full name",
          "transformer": {
            "name": "FakeFullName",
            "args": {
              "deterministic": "true",
              "id_column": "user_id"
            }
          }
        }
      ]
    }
  ]
```
- [] Create an SQL file containing all the commands needed to recreate your database: `pg_dump -x --no-owner test_anonymiser_db > dump.sql`
- [] run anonymizer script: `cargo run -- anonymise -i dump.sql -o anon.sql -s <YOUR_STRATEGY_JSON_FILEPATH>`
- [] add anon SQL to anonymized_db: `psql anonymized_db < anon.sql`
- [] check the both db have the original data and anonymized data and that the naming is consistent
- [] Repeat instructions above by removing salt in strategy.json file