### PR TITLE
Update anonymiser tool to hash ID's

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,18 @@ Transforming table data requires a list of all table columns with a transformer 
 - FakeCompanyName * - Random Company Name from [faker](https://github.com/cksac/fake-rs)
 - FakeEmail * - Random email address from [faker](https://github.com/cksac/fake-rs)
 - FakeEmailOrPhone * - Either a random phone number OR a random email depending on whether the existing data starts with a `+` and doesn't contain an `@` symbol or not!
-- FakeFirstName† - Random first name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
+- FakeFirstName†† - Random first name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
 - FakeFullAddress - Random address made up of segments from [faker](https://github.com/cksac/fake-rs)
-- FakeFullName† - Random first plus last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
+- FakeFullName†† - Random first plus last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
 - FakeIPv4 - Random IPV4 address from [faker](https://github.com/cksac/fake-rs)
-- FakeLastName†- Random last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
+- FakeLastName††- Random last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
 - FakeNationalIdentityNumber - Random National Insurance number from list of dummy numbers
 - FakePhoneNumber - Random phone number (looks at existing numbers country code, supports GB + US)
 - FakePostCode - Truncates postcode to the first 3 chars e.g. NW5
 - FakeState - Random US state from [faker](https://github.com/cksac/fake-rs)
 - FakeStreetAddress - Random building number + street name from [faker](https://github.com/cksac/fake-rs)
 - FakeUsername * - Random username from [faker](https://github.com/cksac/fake-rs)
-- FakeUUID - Random UUIDv4
+- FakeUUID† - Random UUIDv4
 - Fixed - Returns a fixed value (requires a `value` arg with the value to use)
 - Identity - Does not transform the original value
 - ObfuscateDay - Takes a date and sets the day to the first of the month e.g. 12-12-2000 becomes 01-12-2000
@@ -122,7 +122,7 @@ Transformers with a * support the arg `unique` which will append an incrementing
   },
 ```
 
-Transformers with a † support deterministic generation by setting `deterministic: true` and providing an `id_column` argument. This ensures the same input and ID always generate the same fake data.
+Transformers with a † or †† support deterministic generation by setting `deterministic: true`. Transformers with a †† also require an `id_column` argument. This ensures the same input and ID always generate the same fake data.
 
 Example of deterministic name generation:
 ```json

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Transforming table data requires a list of all table columns with a transformer 
 - FakeCompanyName * - Random Company Name from [faker](https://github.com/cksac/fake-rs)
 - FakeEmail * - Random email address from [faker](https://github.com/cksac/fake-rs)
 - FakeEmailOrPhone * - Either a random phone number OR a random email depending on whether the existing data starts with a `+` and doesn't contain an `@` symbol or not!
-- FakeFirstName†† - Random first name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
+- FakeFirstName† - Random first name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
 - FakeFullAddress - Random address made up of segments from [faker](https://github.com/cksac/fake-rs)
-- FakeFullName†† - Random first plus last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
+- FakeFullName† - Random first plus last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
 - FakeIPv4 - Random IPV4 address from [faker](https://github.com/cksac/fake-rs)
-- FakeLastName††- Random last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
+- FakeLastName†- Random last name from [faker](https://github.com/cksac/fake-rs). Supports deterministic generation by setting `deterministic: true` and providing an `id_column` argument
 - FakeNationalIdentityNumber - Random National Insurance number from list of dummy numbers
 - FakePhoneNumber - Random phone number (looks at existing numbers country code, supports GB + US)
 - FakePostCode - Truncates postcode to the first 3 chars e.g. NW5
@@ -122,7 +122,7 @@ Transformers with a * support the arg `unique` which will append an incrementing
   },
 ```
 
-Transformers with a † or †† support deterministic generation by setting `deterministic: true`. Transformers with a †† also require an `id_column` argument. This ensures the same input and ID always generate the same fake data.
+Transformers with a † support deterministic generation by setting `deterministic: true` and providing required `id_column` argument (except for fakeUUID transformer, which doesn't require an id_column). This ensures the same input and ID always generate the same fake data.
 
 Example of deterministic name generation:
 ```json

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Transforming table data requires a list of all table columns with a transformer 
 - FakeState - Random US state from [faker](https://github.com/cksac/fake-rs)
 - FakeStreetAddress - Random building number + street name from [faker](https://github.com/cksac/fake-rs)
 - FakeUsername * - Random username from [faker](https://github.com/cksac/fake-rs)
-- FakeUUID† - Random UUIDv4
+- FakeUUID† - Random UUIDv4, Supports deterministic generation by setting `deterministic: true`
 - Fixed - Returns a fixed value (requires a `value` arg with the value to use)
 - Identity - Does not transform the original value
 - ObfuscateDay - Takes a date and sets the day to the first of the month e.g. 12-12-2000 becomes 01-12-2000

--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -127,6 +127,13 @@ fn transform_row_with_columns(
 ) -> String {
     let column_values: Vec<String> = data_row::split(line).map(|s| s.to_string()).collect();
 
+    // Create a vector of (column_name, value) pairs
+    let column_name_values: Vec<(String, String)> = columns
+        .iter()
+        .zip(column_values.iter())
+        .map(|(col, val)| (col.name.clone(), val.clone()))
+        .collect();
+
     let mut transformed = column_values.iter().enumerate().map(|(i, value)| {
         let current_column = &columns[i];
         let column_type = types
@@ -142,13 +149,6 @@ fn transform_row_with_columns(
                     types.for_table(table_name)
                 )
             });
-
-        // Create a vector of (column_name, value) pairs
-        let column_name_values: Vec<(String, String)> = columns
-            .iter()
-            .zip(column_values.iter())
-            .map(|(col, val)| (col.name.clone(), val.clone()))
-            .collect();
 
         transformer::transform(
             rng,

--- a/src/parsers/strategies.rs
+++ b/src/parsers/strategies.rs
@@ -843,8 +843,6 @@ mod tests {
             }],
         }];
 
-        // This should succeed (no errors) since FakeUUID is allowed to have
-        // deterministic=true without an id_column
         let result = Strategies::from_strategies_in_file(strategies, &TransformerOverrides::none());
         assert!(result.is_ok());
     }

--- a/src/parsers/strategies.rs
+++ b/src/parsers/strategies.rs
@@ -47,7 +47,6 @@ impl Strategies {
                 continue;
             }
 
-            // Validate deterministic settings
             validate_deterministic_settings(&strategy, &mut errors);
 
             if strategy.truncate {

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -28,6 +28,7 @@ fn get_unique() -> usize {
     UNIQUE_INTEGER.fetch_add(1, Ordering::SeqCst)
 }
 
+
 fn get_faker_rng(value: &str, id: Option<&str>, salt: Option<&str>) -> SmallRng {
     let mut hasher = Sha256::new();
     let combined = match (id, salt) {
@@ -334,6 +335,20 @@ fn fake_full_address() -> String {
     let city_name: String = CityName().fake();
     let state: String = StateName().fake();
     format!("{}, {}, {}", line_1, city_name, state)
+}
+
+fn fake_uuid(
+    value: &str,
+    args: &Option<HashMap<String, String>>,
+    global_salt: Option<&str>,
+) -> String {
+    if !is_deterministic(args) {
+        return Uuid::new_v4().to_string()
+    }
+
+    let mut seeded_rng = get_faker_rng(value, None, global_salt);
+
+    FirstName().fake_with_rng::<String, _>(&mut seeded_rng)
 }
 
 fn fake_first_name(

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -367,7 +367,8 @@ fn fake_uuid(
 
     let mut seeded_rng = get_faker_rng(value, None, global_salt);
 
-    FirstName().fake_with_rng::<String, _>(&mut seeded_rng)
+    let random_bytes = seeded_rng.gen::<[u8; 16]>();
+    Uuid::from_bytes(random_bytes).to_string()
 }
 
 fn fake_first_name(

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -366,14 +366,7 @@ fn fake_uuid(
 
     let mut seeded_rng = get_faker_rng(value, None, global_salt);
 
-    // Generate 16 random bytes for the UUID
-    let mut bytes = seeded_rng.gen::<[u8; 16]>();
-
-    // Set the version (v4) and variant bits according to RFC4122
-    bytes[6] = (bytes[6] & 0x0f) | 0x40; // Version 4
-    bytes[8] = (bytes[8] & 0x3f) | 0x80; // Variant 1
-
-    Uuid::from_bytes(bytes).to_string()
+    Uuid::from_bytes(seeded_rng.gen()).to_string()
 }
 
 fn fake_first_name(

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -386,8 +386,8 @@ fn fake_first_name(
     let id_to_use = if deterministic { id } else { None };
 
     match id_to_use {
-        Some(id) => {
-            let mut seeded_rng = get_faker_rng(value, Some(id), global_salt);
+        Some(id_value) => {
+            let mut seeded_rng = get_faker_rng(value, Some(id_value), global_salt);
             FirstName().fake_with_rng::<String, _>(&mut seeded_rng)
         }
         None => FirstName().fake::<String>(),

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -379,8 +379,8 @@ fn fake_first_name(
     let id_to_use = if deterministic { id } else { None };
 
     match id_to_use {
-        Some(id_value) => {
-            let mut seeded_rng = get_faker_rng(value, Some(id_value), global_salt);
+        Some(id) => {
+            let mut seeded_rng = get_faker_rng(value, Some(id), global_salt);
             FirstName().fake_with_rng::<String, _>(&mut seeded_rng)
         }
         None => FirstName().fake::<String>(),

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -28,7 +28,26 @@ fn get_unique() -> usize {
     UNIQUE_INTEGER.fetch_add(1, Ordering::SeqCst)
 }
 
-
+/// Creates a deterministic random number generator from input parameters.
+/// 
+/// # Arguments
+/// 
+/// * `value` - Base value to seed the RNG
+/// * `id` - Optional identifier to ensure consistent generation for the same entity
+/// * `salt` - Optional global salt to vary generation between runs
+/// 
+/// # Returns
+/// 
+/// A deterministic `SmallRng` that will produce the same sequence of values
+/// for identical inputs.
+/// 
+/// # Example
+/// 
+/// ```
+/// let rng = get_faker_rng("John", Some("123"), Some("global_salt"));
+/// let name = FirstName().fake_with_rng::<String, _>(&mut rng.clone());
+/// // Will always produce the same name for the same inputs
+/// ```
 fn get_faker_rng(value: &str, id: Option<&str>, salt: Option<&str>) -> SmallRng {
     let mut hasher = Sha256::new();
     let combined = match (id, salt) {

--- a/src/parsers/transformer.rs
+++ b/src/parsers/transformer.rs
@@ -41,12 +41,17 @@ fn get_unique() -> usize {
 /// A deterministic `SmallRng` that will produce the same sequence of values
 /// for identical inputs.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
-/// let rng = get_faker_rng("John", Some("123"), Some("global_salt"));
-/// let name = FirstName().fake_with_rng::<String, _>(&mut rng.clone());
-/// // Will always produce the same name for the same inputs
+/// // Basic usage with just a value
+/// let rng1 = get_faker_rng("test", None, None);
+///
+/// // With an ID for entity-level consistency
+/// let rng2 = get_faker_rng("test", Some("user_123"), None);
+///
+/// // With both ID and salt for run-level consistency
+/// let rng3 = get_faker_rng("test", Some("user_123"), Some("global_salt_2024"));
 /// ```
 fn get_faker_rng(value: &str, id: Option<&str>, salt: Option<&str>) -> SmallRng {
     let mut hasher = Sha256::new();


### PR DESCRIPTION
([SQD-67](https://linear.app/multiverse-io/issue/SQD-67/update-anonymiser-tool-to-hash-ids))
## Introduction
As part of the anonymisation work we should be anonymising some id's to make it harder to link back to our production data. This PR adds this functionality

## Test Steps
- [ ] create test db and test anonymizer db: `createdb test_anonymiser_db` and `createdb anonymized_db`
- [ ] create sql file `test_db.sql` and add the following.
```
CREATE TABLE public.users (
      user_id SERIAL,
      account_id VARCHAR(255),
      customer_id VARCHAR(255),
      user_uuid UUID,
      first_name VARCHAR(255),
      last_name VARCHAR(255),
      full_name VARCHAR(255)
  );

  INSERT INTO public.users (user_id, account_id, customer_id, user_uuid, first_name, last_name, full_name) VALUES 
      (1, 'ACC_001', 'CUST_001', '123e4567-e89b-12d3-a456-426614174000', 'John', 'Smith', 'John Smith'),
      (2, 'ACC_001', 'CUST_002', '223e4567-e89b-12d3-a456-426614174001', 'John', 'Brown', 'John Brown'),
      (3, 'ACC_002', 'CUST_001', '323e4567-e89b-12d3-a456-426614174002', 'Mary', 'Smith', 'Mary Smith'),
      (4, 'ACC_003', 'CUST_003', '423e4567-e89b-12d3-a456-426614174003', 'John', 'Smith', 'John Smith');

  -- View the original data
  SELECT * FROM public.users;
```
- [ ] populate test db with the data from the sql file: `psql test_anonymiser_db < test_db.sql`
- [ ] update strategy.json or create new strategy for hashing user_uuid etc. example strategy.json below:
```
[
    {
      "table_name": "public.users",
      "description": "User table for testing",
      "truncate": false,
      "columns": [
        {
          "name": "user_id",
          "data_category": "General",
          "description": "User identifier",
          "transformer": {
            "name": "Identity"
          }
        },
        {
          "name": "account_id",
          "data_category": "General",
          "description": "Account identifier",
          "transformer": {
            "name": "Identity"
          }
        },
        {
          "name": "customer_id",
          "data_category": "General",
          "description": "Customer identifier",
          "transformer": {
            "name": "Identity"
          }
        },
        {
          "name": "user_uuid",
          "data_category": "General",
          "description": "User UUID",
          "transformer": {
            "name": "FakeUUID",
            "args": {
              "deterministic": "true"
            }
          }
        },
        {
          "name": "first_name",
          "data_category": "Pii",
          "description": "User's first name",
          "transformer": {
            "name": "FakeFirstName",
            "args": {
              "deterministic": "true",
              "id_column": "user_uuid"
            }
          }
        },
        {
          "name": "last_name",
          "data_category": "Pii",
          "description": "User's last name",
          "transformer": {
            "name": "FakeLastName",
            "args": {
              "deterministic": "true",
              "id_column": "user_uuid"
            }
          }
        },
        {
          "name": "full_name",
          "data_category": "Pii",
          "description": "User's full name",
          "transformer": {
            "name": "FakeFullName",
            "args": {
              "deterministic": "true",
              "id_column": "user_uuid"
            }
          }
        }
      ]
    }
  ]
```
- [ ] Create an SQL file containing all the commands needed to recreate your database: `pg_dump -x --no-owner test_anonymiser_db > dump.sql`
- [ ] run anonymizer script: `cargo run -- anonymise -i dump.sql -o anon.sql -s <YOUR_STRATEGY_JSON_FILEPATH>`
- [ ] add anon SQL to anonymized_db: `psql anonymized_db < anon.sql`
- [ ] check that both db have the original data and anonymized data and that the naming is consistent
- [ ] create another anonymized db `createdb anonymized_db2`
- [ ] update strategy.json so that user_uuid is not hashed as shown below:
```
        {
          "name": "user_uuid",
          "data_category": "General",
          "description": "User UUID",
          "transformer": {
            "name": "Identity"
          }
        },
       
```
- [ ] run anonymizer script again and save to a different sql: `cargo run -- anonymise -i dump.sql -o anon2.sql -s <YOUR_STRATEGY_JSON_FILEPATH>`
- [ ] add new anon SQL to new anonymized_db: `psql anonymized_db2 < anon2.sql`
- [ ] check that first and last names are the same in both anonymized_db and anoymized_db2. This is testing that original value for user_uuid is used when anonymising first_name, last_name and full_name regardless of whether the user_uuid column has been hashed or not 
