### PR TITLE
Handle rows where the first column is text and starts with "COPY"

### DIFF
--- a/src/parsers/row_parser.rs
+++ b/src/parsers/row_parser.rs
@@ -26,7 +26,7 @@ enum RowType {
 fn row_type(line: &str, state: &Position) -> RowType {
     if create_row::is_create_row(line) {
         RowType::CreateTableStart
-    } else if line.starts_with("COPY ") {
+    } else if line.starts_with("COPY ") && !line.contains("\t") {
         RowType::CopyBlockStart
     } else if line.starts_with("\\.") {
         RowType::CopyBlockEnd
@@ -351,6 +351,17 @@ mod tests {
             }
             _other => unreachable!("Position is not InCopy!"),
         };
+    }
+
+    #[test]
+    fn row_type_handles_text_columns_starting_with_copy() {
+        let not_a_copy_row = "COPY CELLS WITH FORMULA AND PASTE\t9b8d3a9b-e84a-4f84-8fb2-0b1e862506d1\t\\N";
+        let state = State {
+            position: Position::Normal,
+            types: Types::new(HashMap::default()),
+        };
+        let row_type = row_type(not_a_copy_row, &state.position);
+        assert_eq!(RowType::Normal, row_type);
     }
 
     #[test]


### PR DESCRIPTION
Ran into this with a column containing a user-sent message.
Unfortunately our table is setup so that the `text` column is first when it would usually be an ID where this wouldn't be a problem, but this is technically valid anyway