### PR TITLE
Add helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,65 @@ The anonymiser supports using a global salt for consistent hashing across differ
 ```
 
 The salt will be applied to all transformers that support salted hashing (marked with † in the transformer list). Different salt values will generate different outputs for the same input
+
+## Helper Functions for Local Debugging
+
+The anonymiser provides helper functions that can be used to get anonymised values for specific inputs. This is particularly useful for local debugging scenarios where you need to match production user IDs or emails to their anonymised counterparts.
+
+### Anonymise Email
+
+Get an anonymised email address for a given email:
+
+```bash
+anonymiser anonymise-email --email "user@example.com"
+# Output: b4c9a289323b-cordia_iusto@hotmail.com
+
+# With salt for different outputs
+anonymiser anonymise-email --email "user@example.com" --salt "mysalt123"
+# Output: b4c9a289323b-justus_ut@yahoo.com
+```
+
+### Anonymise ID
+
+Get an anonymised ID for a given ID value:
+
+```bash
+# Using FakeUUID transformer with deterministic generation
+anonymiser anonymise-id --id "user123" --transformer "FakeUUID" --args '{"deterministic": "true"}'
+# Output: e4d6655a-4a20-1c4a-6740-d647ba4bf06e
+
+# Using Scramble transformer
+anonymiser anonymise-id --id "user456" --transformer "Scramble"
+# Output: llzm895
+
+# With salt for different outputs
+anonymiser anonymise-id --id "user123" --transformer "FakeUUID" --args '{"deterministic": "true"}' --salt "mysalt123"
+```
+
+
+
+### Use Case: Local Debugging
+
+When teams update their strategy.json files to anonymise user IDs and emails, they can use these helper functions to:
+
+1. **Match Production Users**: Take a production user ID or email and get its anonymised equivalent
+2. **Consistent Debugging**: Use the same salt and transformer settings as your strategy.json to ensure consistent results
+3. **Quick Testing**: Test different transformer configurations before updating your strategy file
+
+#### Example Workflow:
+
+1. You have a production user with email `john.smith@company.com` and ID `12345`
+2. Your strategy.json anonymises emails with `FakeEmail` and IDs with `FakeUUID` (deterministic)
+3. Get the anonymised values:
+
+```bash
+# Get anonymised email
+anonymiser anonymise-email --email "john.smith@company.com"
+
+# Get anonymised ID (matching your strategy.json configuration)
+anonymiser anonymise-id --id "12345" --transformer "FakeUUID" --args '{"deterministic": "true"}'
+```
+
+4. Use these anonymised values to identify the same user in your local anonymised database
+
+This allows you to maintain the debugging workflow while keeping data properly anonymised and following security best practices.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,125 @@
+use crate::parsers::strategy_structs::{Transformer, TransformerType};
+use crate::parsers::transformer;
+use crate::parsers::types::Type;
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+use std::collections::HashMap;
+
+/// Anonymise an email address using the FakeEmail transformer
+pub fn anonymise_email(email: &str, global_salt: Option<&str>) -> Result<String, String> {
+    // Create a transformer struct
+    let transformer = Transformer {
+        name: TransformerType::FakeEmail,
+        args: None,
+    };
+
+    // Create a dummy RNG (will be replaced by transformer's internal RNG for deterministic operations)
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    // Use string type as default
+    let column_type = Type::SingleValue {
+        sub_type: crate::parsers::types::SubType::Character,
+    };
+
+    // Call the transformer
+    let result = transformer::transform(
+        &mut rng,
+        email,
+        &column_type,
+        &transformer,
+        "helper_table", // dummy table name
+        &[],
+        global_salt,
+    );
+
+    Ok(result.into_owned())
+}
+
+/// Anonymise an ID using the specified transformer
+pub fn anonymise_id(
+    id: &str,
+    transformer_type: TransformerType,
+    args: Option<HashMap<String, String>>,
+    global_salt: Option<&str>,
+) -> Result<String, String> {
+    // Create a transformer struct
+    let transformer = Transformer {
+        name: transformer_type,
+        args,
+    };
+
+    // Create a dummy RNG (will be replaced by transformer's internal RNG for deterministic operations)
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    // Use string type as default
+    let column_type = Type::SingleValue {
+        sub_type: crate::parsers::types::SubType::Character,
+    };
+
+    // Call the transformer
+    let result = transformer::transform(
+        &mut rng,
+        id,
+        &column_type,
+        &transformer,
+        "helper_table", // dummy table name
+        &[],
+        global_salt,
+    );
+
+    Ok(result.into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_anonymise_email() {
+        let email = "test@example.com";
+        let result = anonymise_email(email, None).unwrap();
+
+        // Should not be the same as input
+        assert_ne!(result, email);
+
+        // Should be deterministic
+        let result2 = anonymise_email(email, None).unwrap();
+        assert_eq!(result, result2);
+
+        // Should contain a hash prefix
+        assert!(result.contains('-'));
+    }
+
+    #[test]
+    fn test_anonymise_id_with_fake_uuid() {
+        let id = "12345";
+        let mut args = HashMap::new();
+        args.insert("deterministic".to_string(), "true".to_string());
+
+        let result = anonymise_id(id, TransformerType::FakeUUID, Some(args), None).unwrap();
+
+        // Should not be the same as input
+        assert_ne!(result, id);
+
+        // Should be deterministic
+        let mut args2 = HashMap::new();
+        args2.insert("deterministic".to_string(), "true".to_string());
+        let result2 = anonymise_id(id, TransformerType::FakeUUID, Some(args2), None).unwrap();
+        assert_eq!(result, result2);
+
+        // Should be a valid UUID format
+        assert!(result.len() == 36); // UUID length with hyphens
+    }
+
+    #[test]
+    fn test_anonymise_id_with_scramble() {
+        let id = "user123";
+        let result = anonymise_id(id, TransformerType::Scramble, None, None).unwrap();
+
+        // Should not be the same as input
+        assert_ne!(result, id);
+
+        // Should maintain the same length
+        assert_eq!(result.len(), id.len());
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,7 +5,6 @@ use rand::rngs::SmallRng;
 use rand::SeedableRng;
 use std::collections::HashMap;
 
-
 const HELPER_TABLE_NAME: &str = "anonymiser_helper";
 
 /// Anonymise an email address using the FakeEmail transformer

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,6 +5,9 @@ use rand::rngs::SmallRng;
 use rand::SeedableRng;
 use std::collections::HashMap;
 
+
+const HELPER_TABLE_NAME: &str = "anonymiser_helper";
+
 /// Anonymise an email address using the FakeEmail transformer
 pub fn anonymise_email(email: &str, global_salt: Option<&str>) -> Result<String, String> {
     // Create a transformer struct
@@ -27,7 +30,7 @@ pub fn anonymise_email(email: &str, global_salt: Option<&str>) -> Result<String,
         email,
         &column_type,
         &transformer,
-        "helper_table", // dummy table name
+        HELPER_TABLE_NAME,
         &[],
         global_salt,
     );
@@ -62,7 +65,7 @@ pub fn anonymise_id(
         id,
         &column_type,
         &transformer,
-        "helper_table", // dummy table name
+        HELPER_TABLE_NAME,
         &[],
         global_salt,
     );

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -102,4 +102,30 @@ pub enum Anonymiser {
         #[structopt(short, long)]
         output_file: Option<PathBuf>,
     },
+
+    /// Get anonymised email for a given email address
+    AnonymiseEmail {
+        /// Original email address to anonymise
+        #[structopt(long)]
+        email: String,
+        /// Optional global salt for deterministic generation
+        #[structopt(long)]
+        salt: Option<String>,
+    },
+
+    /// Get anonymised ID for a given ID value
+    AnonymiseId {
+        /// Original ID value to anonymise
+        #[structopt(long)]
+        id: String,
+        /// Transformer type (e.g., "FakeUUID", "Scramble")
+        #[structopt(long)]
+        transformer: String,
+        /// Optional transformer arguments in JSON format (e.g., '{"deterministic": "true"}')
+        #[structopt(long)]
+        args: Option<String>,
+        /// Optional global salt for deterministic generation
+        #[structopt(long)]
+        salt: Option<String>,
+    },
 }


### PR DESCRIPTION
Adds two new CLI commands to help teams debug production issues locally by getting anonymised versions of production user IDs and emails

## Testing
1. `cargo build`
2. Basic Email Anonymisation Testing
```
./target/debug/anonymiser anonymise-email --email "user@example.com"
# Expected: Deterministic output like "b4c9a289323b-cordia_iusto@hotmail.com"

# Test deterministic behavior (should produce identical output)
./target/debug/anonymiser anonymise-email --email "user@example.com"

# Test different emails produce different outputs
./target/debug/anonymiser anonymise-email --email "different@example.com"
```
3. ID Anonymisation Testing
```
# Test FakeUUID transformer with deterministic generation
./target/debug/anonymiser anonymise-id --id "user123" --transformer "FakeUUID" --args '{"deterministic": "true"}'
# Expected: UUID format like "e4d6655a-4a20-1c4a-6740-d647ba4bf06e"

# Test ID anonymisation with salt
./target/debug/anonymiser anonymise-id --id "user123" --transformer "FakeUUID" --args '{"deterministic": "true"}' --salt "prod2024"
```

4.  documentation help: `./target/debug/anonymiser --help`