### PR TITLE
fix: update CircleCI macOS resource class from m1 to m4pro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
   build_release_macos:
     macos:
       xcode: 15.4
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
       CARGO_NET_GIT_FETCH_WITH_CLI: true


### PR DESCRIPTION
https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/