### PR TITLE
fix: bump tokio to 1.43.1 for GHSA-rr8g-9fpq-6wmg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,9 +1305,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
updates tokio from 1.43.0 to 1.43.1 in Cargo.lock to remediate GHSA-rr8g-9fpq-6wmg